### PR TITLE
Add slug utilities and retrieval functions

### DIFF
--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -55,6 +55,16 @@ class MongoCrud(Generic[T]):
             print(f"❌ Failed to retrieve document by id {_id}: {e}")
             return None
 
+    async def get_by_slug(self, slug: str, slug_field: str = "slug") -> Optional[T]:
+        try:
+            raw = await self.model.get_motor_collection().find_one({slug_field: slug})
+            if not raw:
+                return None
+            return self.model.model_validate(raw)
+        except Exception as e:
+            print(f"❌ Failed to retrieve document by slug {slug}: {e}")
+            return None
+
     async def get_by_fields(
             self, filters: Dict[str, Any], skip: int = 0, limit: int = 10
     ) -> List[T]:

--- a/app/schema/category.py
+++ b/app/schema/category.py
@@ -59,5 +59,6 @@ class CategoryDocument(Document, Category):
         indexes = [
             IndexModel([("restaurantId", ASCENDING)], name="idx_restaurant_id"),
             IndexModel([("isActive", ASCENDING)], name="idx_is_active"),
-            IndexModel([("position", ASCENDING)], name="idx_position")
+            IndexModel([("position", ASCENDING)], name="idx_position"),
+            IndexModel([("slug", ASCENDING)], unique=True, name="idx_slug")
         ]

--- a/app/schema/item.py
+++ b/app/schema/item.py
@@ -2,6 +2,7 @@ from beanie import Document
 from bson import ObjectId
 from pydantic import BaseModel, Field
 from typing import List, Optional
+from pymongo import IndexModel, ASCENDING
 from enum import Enum
 from app.schema.collection_id.document_id import DocumentId
 from app.utils.make_optional_model import make_optional_model
@@ -48,6 +49,7 @@ class ItemBase(ItemCreate):
 
     # Optional
     is_available: bool = Field(default=True, alias="isAvailable")
+    slug: Optional[str] = None
 
 
 ItemUpdate = make_optional_model(ItemBase)
@@ -68,5 +70,8 @@ class ItemDocument(Document, Item):
     class Settings:
         name = "items"
         bson_encoders = {ObjectId: str}
+        indexes = [
+            IndexModel([("slug", ASCENDING)], unique=True, name="idx_slug")
+        ]
 
 

--- a/app/schema/menu.py
+++ b/app/schema/menu.py
@@ -29,6 +29,7 @@ class MenuBase(MenuCreate):
     is_active: bool = Field(default=True, alias="isActive")
     position: int = 0  # Menu ordering preference (e.g., Lunch = 1, Dinner = 2)
     preferences: Optional[MenuPreferences] = Field(default_factory=MenuPreferences)
+    slug: Optional[str] = None
 
 
 MenuUpdate = make_optional_model(MenuBase)
@@ -59,5 +60,6 @@ class MenuDocument(Document, Menu):
         indexes = [
             IndexModel([("restaurantId", ASCENDING)], name="idx_restaurant_id"),
             IndexModel([("isActive", ASCENDING)], name="idx_is_active"),
-            IndexModel([("position", ASCENDING)], name="idx_position")
+            IndexModel([("position", ASCENDING)], name="idx_position"),
+            IndexModel([("slug", ASCENDING)], unique=True, name="idx_slug")
         ]

--- a/app/schema/restaurant.py
+++ b/app/schema/restaurant.py
@@ -41,6 +41,7 @@ class RestaurantBase(RestaurantCreate):
     table_ids: List[str] = Field(default_factory=list, alias="tableIds")    # Tables
     session_ids: List[str] = Field(default_factory=list, alias="sessionIds") # Sessions
     order_ids: List[str] = Field(default_factory=list, alias="orderIds")    # Orders
+    slug: Optional[str] = None
 
 
 
@@ -67,5 +68,6 @@ class RestaurantDocument(Document, Restaurant):
             IndexModel([("name", ASCENDING)], name="idx_name"),
             IndexModel([("isActive", ASCENDING)], name="idx_is_active"),
             # Optional if you want to guarantee unique phone numbers:
-            IndexModel([("phoneNumber", ASCENDING)], unique=True, name="idx_phone_number")
+            IndexModel([("phoneNumber", ASCENDING)], unique=True, name="idx_phone_number"),
+            IndexModel([("slug", ASCENDING)], unique=True, name="idx_slug")
         ]

--- a/app/services/category.py
+++ b/app/services/category.py
@@ -1,10 +1,13 @@
 from app.models.category import CategoryModel
 from app.schema import category as category_schema
+from app.utils.slug import generate_unique_slug
 
 category_model = CategoryModel()
 
 async def create_category(data: category_schema.CategoryCreate):
-    return await category_model.create(data.model_dump(by_alias=False))
+    payload = data.model_dump(by_alias=False)
+    payload["slug"] = await generate_unique_slug(payload["name"], category_schema.CategoryDocument)
+    return await category_model.create(payload)
 
 async def update_category(category_id: str, data: category_schema.CategoryUpdate):
     return await category_model.update(category_id, data)
@@ -37,3 +40,6 @@ async def remove_item_from_category(category_id: str, item_id: str):
         await category_model.update(category_id, {"itemIds": category.item_ids})
 
     return category
+
+async def get_category_by_slug(slug: str):
+    return await category_model.get_by_slug(slug)

--- a/app/services/item.py
+++ b/app/services/item.py
@@ -1,9 +1,13 @@
 from app.models.item import ItemModel
+from app.utils.slug import generate_unique_slug
+from app.schema import item as item_schema
 
 item_model = ItemModel()
 
 async def create_item(data: dict):
-    return await item_model.create(data)
+    payload = data.copy()
+    payload["slug"] = await generate_unique_slug(payload["name"], item_schema.ItemDocument)
+    return await item_model.create(payload)
 
 async def update_item(item_id: str, data: dict):
     return await item_model.update(item_id, data)
@@ -17,4 +21,7 @@ async def list_items_by_category(category_id: str):
         "isAvailable": True
     }
     return await item_model.get_by_fields(filters)
+
+async def get_item_by_slug(slug: str):
+    return await item_model.get_by_slug(slug)
 

--- a/app/services/menu.py
+++ b/app/services/menu.py
@@ -1,11 +1,14 @@
 from app.models.menu import MenuModel
 from app.schema import menu as menu_schema
+from app.utils.slug import generate_unique_slug
 
 
 menu_model = MenuModel()
 
 async def create_menu(data: menu_schema.MenuCreate):
-    return await menu_model.create(data.model_dump(by_alias=False))
+    payload = data.model_dump(by_alias=False)
+    payload["slug"] = await generate_unique_slug(payload["name"], menu_schema.MenuDocument)
+    return await menu_model.create(payload)
 
 async def update_menu(menu_id: str, data: menu_schema.MenuUpdate):
     return await menu_model.update(menu_id, data)
@@ -21,6 +24,9 @@ async def deactivate_menu(menu_id: str):
 
 async def get_menu(menu_id: str):
     return await menu_model.get(menu_id)
+
+async def get_menu_by_slug(slug: str):
+    return await menu_model.get_by_slug(slug)
 
 async def list_menus(restaurant_id: str):
     filters = {"restaurantId": restaurant_id, "isActive": True}

--- a/app/services/restaurant.py
+++ b/app/services/restaurant.py
@@ -2,13 +2,16 @@ from fastapi import HTTPException
 
 from app.models.restaurant import RestaurantModel
 from app.schema import restaurant as restaurant_schema
+from app.utils.slug import generate_unique_slug
 
 
 restaurant_model = RestaurantModel()
 
 async def create_restaurant(data: restaurant_schema.RestaurantCreate):
     try:
-        return await restaurant_model.create(data.model_dump(by_alias=False))
+        payload = data.model_dump(by_alias=False)
+        payload["slug"] = await generate_unique_slug(payload["name"], restaurant_schema.RestaurantDocument)
+        return await restaurant_model.create(payload)
     except Exception as error:
         print(error)
         raise HTTPException(detail=str(error), status_code=500)
@@ -35,5 +38,8 @@ async def deactivate_restaurant(restaurant_id: str):
 
 async def get_restaurant(restaurant_id: str):
     return await restaurant_model.get(restaurant_id)
+
+async def get_restaurant_by_slug(slug: str):
+    return await restaurant_model.get_by_slug(slug)
 
 

--- a/app/utils/slug.py
+++ b/app/utils/slug.py
@@ -1,0 +1,21 @@
+import re
+from typing import Type
+from beanie import Document
+
+
+def slugify(text: str) -> str:
+    slug = re.sub(r'[^a-zA-Z0-9]+', '-', text.lower())
+    slug = re.sub(r'-{2,}', '-', slug).strip('-')
+    return slug
+
+
+async def generate_unique_slug(name: str, model: Type[Document], slug_field: str = "slug") -> str:
+    base_slug = slugify(name)
+    slug = base_slug
+    counter = 1
+    existing = await model.find_one({slug_field: slug})
+    while existing:
+        counter += 1
+        slug = f"{base_slug}-{counter}"
+        existing = await model.find_one({slug_field: slug})
+    return slug


### PR DESCRIPTION
## Summary
- introduce `app/utils/slug.py` with helpers to slugify names and generate unique slugs
- store slug field on restaurants, menus, categories and items
- ensure slug uniqueness via indexes
- generate slugs when creating restaurants, menus, categories and items
- allow fetching records by slug via new `MongoCrud.get_by_slug` and service helpers

## Testing
- `pytest -q`
- `ruff check .` *(fails: Found 38 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6840d2c8ea9c8333b9f079ca600f230e