### PR TITLE
Implement menu management endpoints

### DIFF
--- a/app/api/v1/endpoint/menus.py
+++ b/app/api/v1/endpoint/menus.py
@@ -1,0 +1,40 @@
+from fastapi import APIRouter, HTTPException
+
+from app.schema import menu as menu_schema
+from app.services import menu as menu_service
+
+router = APIRouter()
+
+@router.post("/")
+async def create_menu(data: menu_schema.MenuCreate):
+    try:
+        menu = await menu_service.create_menu(data)
+        return menu.to_response()
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=str(error))
+
+@router.delete("/{menu_id}")
+async def delete_menu(menu_id: str):
+    result = await menu_service.delete_menu(menu_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Menu not found")
+    return True
+
+@router.put("/{menu_id}/status")
+async def update_menu_status(menu_id: str, is_active: bool):
+    try:
+        return await menu_service.update_menu_status(menu_id, is_active)
+    except Exception as error:
+        raise HTTPException(status_code=404, detail=str(error))
+
+@router.get("/{menu_id}")
+async def get_menu(menu_id: str):
+    menu = await menu_service.get_menu(menu_id)
+    if not menu:
+        raise HTTPException(status_code=404, detail="Menu not found")
+    return menu.to_response()
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_restaurant_menus(restaurant_id: str):
+    menus = await menu_service.list_menus(restaurant_id)
+    return [m.to_response() for m in menus]

--- a/app/api/v1/endpoint/restaurants.py
+++ b/app/api/v1/endpoint/restaurants.py
@@ -13,7 +13,10 @@ from app.services.restaurant import (
     get_restaurant,
     update_restaurant,
     delete_restaurant,
-    get_restaurants, get_active_restaurants, restaurant_model,
+    get_restaurants,
+    get_active_restaurants,
+    restaurant_model,
+    change_current_menu,
 )
 from app.schema import restaurant as restaurant_schema
 from app.services.roles import create_default_roles_for_restaurant
@@ -246,6 +249,11 @@ async def get_single_restaurant(restaurant_id: str):
 @router.put("/{restaurant_id}")
 async def update_existing_restaurant(restaurant_id: str, data: restaurant_schema.RestaurantUpdate):
     return await update_restaurant(restaurant_id, data)
+
+
+@router.put("/{restaurant_id}/current-menu/{menu_id}")
+async def change_current_menu_endpoint(restaurant_id: str, menu_id: str):
+    return await change_current_menu(restaurant_id, menu_id)
 
 
 @router.delete("/{restaurant_id}", dependencies=[Depends(admin_required)])

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -7,6 +7,7 @@ from app.api.v1.endpoint.restaurants import router as analysis_router
 from app.api.v1.endpoint.invitation import router as invitation_router
 from app.api.v1.endpoint.blog import router as blog_router
 from app.api.v1.endpoint.bookings import router as booking_router
+from app.api.v1.endpoint.menus import router as menu_router
 from app.api.v1.endpoints.insights import router as insights_router
 
 
@@ -21,3 +22,4 @@ router.include_router(auth_router, prefix="/auth", tags=["Authentication"])
 router.include_router(analytics_router, prefix="/analytics", tags=["Analytics"])
 router.include_router(booking_router, prefix="/bookings", tags=["Bookings"])
 router.include_router(insights_router, prefix="/insights", tags=["AI Insights"])
+router.include_router(menu_router, prefix="/menus", tags=["Menu"])

--- a/app/schema/restaurant.py
+++ b/app/schema/restaurant.py
@@ -38,6 +38,7 @@ class RestaurantBase(RestaurantCreate):
     # Optional fields
     is_active: bool = Field(alias="isActive", default=False, description="Whether the restaurant is active or deactivated")
     menu_ids: List[str] = Field(default_factory=list, alias="menuIds")     # Menus
+    current_menu_id: Optional[str] = Field(default=None, alias="currentMenuId")
     table_ids: List[str] = Field(default_factory=list, alias="tableIds")    # Tables
     session_ids: List[str] = Field(default_factory=list, alias="sessionIds") # Sessions
     order_ids: List[str] = Field(default_factory=list, alias="orderIds")    # Orders

--- a/app/services/menu.py
+++ b/app/services/menu.py
@@ -1,19 +1,49 @@
 from app.models.menu import MenuModel
+from app.models.category import CategoryModel
+from app.models.restaurant import RestaurantModel
 from app.schema import menu as menu_schema
 from app.utils.slug import generate_unique_slug
 
 
 menu_model = MenuModel()
+category_model = CategoryModel()
+restaurant_model = RestaurantModel()
 
 async def create_menu(data: menu_schema.MenuCreate):
     payload = data.model_dump(by_alias=False)
     payload["slug"] = await generate_unique_slug(payload["name"], menu_schema.MenuDocument)
-    return await menu_model.create(payload)
+    menu = await menu_model.create(payload)
+
+    restaurant = await restaurant_model.get(data.restaurant_id)
+    if restaurant:
+        menu_ids = restaurant.menu_ids or []
+        menu_ids.append(str(menu.id))
+        await restaurant_model.update(str(restaurant.id), {"menuIds": menu_ids})
+
+    return menu
 
 async def update_menu(menu_id: str, data: menu_schema.MenuUpdate):
     return await menu_model.update(menu_id, data)
 
 async def delete_menu(menu_id: str):
+    menu = await menu_model.get(menu_id)
+    if not menu:
+        return False
+
+    # Remove categories linked to this menu
+    categories = await category_model.get_by_fields({"menuId": menu_id})
+    for category in categories:
+        await category_model.delete(str(category.id))
+
+    # Remove menu id from restaurant
+    restaurant = await restaurant_model.get(menu.restaurant_id)
+    if restaurant and menu_id in restaurant.menu_ids:
+        new_ids = [mid for mid in restaurant.menu_ids if mid != menu_id]
+        update_data = {"menuIds": new_ids}
+        if restaurant.current_menu_id == menu_id:
+            update_data["currentMenuId"] = None
+        await restaurant_model.update(str(restaurant.id), update_data)
+
     return await menu_model.delete(menu_id)
 
 async def deactivate_menu(menu_id: str):
@@ -21,6 +51,12 @@ async def deactivate_menu(menu_id: str):
     if not menu:
         raise Exception("Menu not found")
     return await menu_model.update(menu_id, {"isActive": False})
+
+async def update_menu_status(menu_id: str, is_active: bool):
+    menu = await menu_model.get(menu_id)
+    if not menu:
+        raise Exception("Menu not found")
+    return await menu_model.update(menu_id, {"isActive": is_active})
 
 async def get_menu(menu_id: str):
     return await menu_model.get(menu_id)

--- a/app/services/restaurant.py
+++ b/app/services/restaurant.py
@@ -42,4 +42,15 @@ async def get_restaurant(restaurant_id: str):
 async def get_restaurant_by_slug(slug: str):
     return await restaurant_model.get_by_slug(slug)
 
+async def change_current_menu(restaurant_id: str, menu_id: str) -> bool:
+    restaurant = await restaurant_model.get(restaurant_id)
+    if not restaurant:
+        raise HTTPException(status_code=404, detail="Restaurant not found")
+
+    if menu_id not in restaurant.menu_ids:
+        raise HTTPException(status_code=400, detail="Menu does not belong to restaurant")
+
+    await restaurant_model.update(restaurant_id, {"currentMenuId": menu_id})
+    return True
+
 

--- a/app/utils/notion.py
+++ b/app/utils/notion.py
@@ -55,7 +55,7 @@ def render_text(text: List[NotionText], base_url: str, escape: bool = True) -> s
         if ann.get("code"):
             classes.append("bg-gray-100 px-1 rounded text-sm font-mono")
 
-        class_attr = f' class="{' '.join(classes)}"' if classes else ""
+        class_attr = f" class=\"{' '.join(classes)}\"" if classes else ""
         wrapped_content = f"<span{class_attr}>{content}</span>"
 
         if not link:


### PR DESCRIPTION
## Summary
- add REST endpoints for menu CRUD
- track `currentMenuId` on restaurants and allow switching
- remove menu categories when deleting menus
- wire up new endpoints in router
- fix syntax in notion util

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840d8a415348333850b35ff3230a9d8