### PR TITLE
Implement item management API

### DIFF
--- a/app/api/v1/endpoints/items.py
+++ b/app/api/v1/endpoints/items.py
@@ -1,0 +1,93 @@
+from fastapi import APIRouter, HTTPException
+
+from app.schema import item as item_schema
+from app.services import item as item_service
+
+router = APIRouter()
+
+
+@router.post("/")
+async def create_item(data: item_schema.ItemCreate):
+    try:
+        created = await item_service.create_item(data.model_dump(by_alias=True))
+        return created.to_response()
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=str(error))
+
+
+@router.get("/{item_id}")
+async def get_item(item_id: str):
+    item = await item_service.get_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item.to_response()
+
+
+@router.put("/{item_id}")
+async def update_item(item_id: str, data: item_schema.ItemUpdate):
+    updated = await item_service.update_item(item_id, data.model_dump(exclude_none=True, by_alias=True))
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return updated.to_response()
+
+
+@router.put("/{item_id}/availability")
+async def switch_item_availability(item_id: str, is_available: bool):
+    updated = await item_service.update_item_availability(item_id, is_available)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return updated.to_response()
+
+
+@router.post("/{item_id}/customizations")
+async def add_customization(item_id: str, customization: item_schema.CustomizationRule):
+    updated = await item_service.add_customization(item_id, customization)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return updated.to_response()
+
+
+@router.put("/{item_id}/customizations/{index}")
+async def update_customization(item_id: str, index: int, customization: item_schema.CustomizationRule):
+    updated = await item_service.update_customization(item_id, index, customization)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item not or customization not found")
+    return updated.to_response()
+
+
+@router.delete("/{item_id}/customizations/{index}")
+async def delete_customization(item_id: str, index: int):
+    updated = await item_service.delete_customization(item_id, index)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item not or customization not found")
+    return updated.to_response()
+
+
+@router.post("/{item_id}/customizations/{c_index}/options")
+async def add_customization_option(item_id: str, c_index: int, option: item_schema.CustomizationOption):
+    updated = await item_service.add_customization_option(item_id, c_index, option)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item or customization not found")
+    return updated.to_response()
+
+
+@router.put("/{item_id}/customizations/{c_index}/options/{o_index}")
+async def update_customization_option(
+    item_id: str,
+    c_index: int,
+    o_index: int,
+    option: item_schema.CustomizationOption,
+):
+    updated = await item_service.update_customization_option(item_id, c_index, o_index, option)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item or option not found")
+    return updated.to_response()
+
+
+@router.delete("/{item_id}/customizations/{c_index}/options/{o_index}")
+async def delete_customization_option(item_id: str, c_index: int, o_index: int):
+    updated = await item_service.delete_customization_option(item_id, c_index, o_index)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item or option not found")
+    return updated.to_response()
+

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -8,6 +8,7 @@ from app.api.v1.endpoints.invitation import router as invitation_router
 from app.api.v1.endpoints.blog import router as blog_router
 from app.api.v1.endpoints.bookings import router as booking_router
 from app.api.v1.endpoints.insights import router as insights_router
+from app.api.v1.endpoints.items import router as items_router
 
 
 router = APIRouter()
@@ -21,3 +22,4 @@ router.include_router(auth_router, prefix="/auth", tags=["Authentication"])
 router.include_router(analytics_router, prefix="/analytics", tags=["Analytics"])
 router.include_router(booking_router, prefix="/bookings", tags=["Bookings"])
 router.include_router(insights_router, prefix="/insights", tags=["AI Insights"])
+router.include_router(items_router, prefix="/items", tags=["Items"])

--- a/app/services/item.py
+++ b/app/services/item.py
@@ -5,17 +5,21 @@ from app.schema import item as item_schema
 item_model = ItemModel()
 
 async def create_item(data: dict):
+    """Create a new item ensuring a unique slug is generated."""
     payload = data.copy()
     payload["slug"] = await generate_unique_slug(payload["name"], item_schema.ItemDocument)
     return await item_model.create(payload)
 
 async def update_item(item_id: str, data: dict):
+    """Update an item by id."""
     return await item_model.update(item_id, data)
 
 async def delete_item(item_id: str):
+    """Delete an item by id."""
     return await item_model.delete(item_id)
 
 async def list_items_by_category(category_id: str):
+    """List all available items for a category."""
     filters = {
         "categoryId": category_id,
         "isAvailable": True
@@ -23,5 +27,96 @@ async def list_items_by_category(category_id: str):
     return await item_model.get_by_fields(filters)
 
 async def get_item_by_slug(slug: str):
+    """Retrieve an item by its slug field."""
     return await item_model.get_by_slug(slug)
+
+async def get_item(item_id: str):
+    """Retrieve an item by its id."""
+    return await item_model.get(item_id)
+
+async def update_item_availability(item_id: str, is_available: bool):
+    """Update only the availability flag of an item."""
+    return await item_model.update(item_id, {"isAvailable": is_available})
+
+
+def _serialize_customizations(customizations: list[item_schema.CustomizationRule]):
+    """Helper to convert customization rules to dicts with aliases."""
+    return [c.model_dump(by_alias=True) for c in customizations]
+
+
+async def add_customization(item_id: str, customization: item_schema.CustomizationRule):
+    """Append a customization rule to an item."""
+    item = await item_model.get(item_id)
+    if not item:
+        return None
+
+    item.customizations.append(customization)
+    return await item_model.update(item_id, {"customizations": _serialize_customizations(item.customizations)})
+
+
+async def update_customization(item_id: str, index: int, customization: item_schema.CustomizationRule):
+    """Replace a customization rule at the given index."""
+    item = await item_model.get(item_id)
+    if not item or index < 0 or index >= len(item.customizations):
+        return None
+
+    item.customizations[index] = customization
+    return await item_model.update(item_id, {"customizations": _serialize_customizations(item.customizations)})
+
+
+async def delete_customization(item_id: str, index: int):
+    """Remove a customization rule from an item."""
+    item = await item_model.get(item_id)
+    if not item or index < 0 or index >= len(item.customizations):
+        return None
+
+    item.customizations.pop(index)
+    return await item_model.update(item_id, {"customizations": _serialize_customizations(item.customizations)})
+
+
+async def add_customization_option(item_id: str, customization_index: int, option: item_schema.CustomizationOption):
+    """Add a customization option to a rule."""
+    item = await item_model.get(item_id)
+    if not item or customization_index < 0 or customization_index >= len(item.customizations):
+        return None
+
+    item.customizations[customization_index].options.append(option)
+    return await item_model.update(item_id, {"customizations": _serialize_customizations(item.customizations)})
+
+
+async def update_customization_option(
+        item_id: str,
+        customization_index: int,
+        option_index: int,
+        option: item_schema.CustomizationOption,
+):
+    """Update a customization option by its index."""
+    item = await item_model.get(item_id)
+    if (
+        not item
+        or customization_index < 0
+        or customization_index >= len(item.customizations)
+        or option_index < 0
+        or option_index >= len(item.customizations[customization_index].options)
+    ):
+        return None
+
+    item.customizations[customization_index].options[option_index] = option
+    return await item_model.update(item_id, {"customizations": _serialize_customizations(item.customizations)})
+
+
+async def delete_customization_option(item_id: str, customization_index: int, option_index: int):
+    """Delete a customization option from a rule."""
+    item = await item_model.get(item_id)
+    if (
+        not item
+        or customization_index < 0
+        or customization_index >= len(item.customizations)
+        or option_index < 0
+        or option_index >= len(item.customizations[customization_index].options)
+    ):
+        return None
+
+    item.customizations[customization_index].options.pop(option_index)
+    return await item_model.update(item_id, {"customizations": _serialize_customizations(item.customizations)})
 


### PR DESCRIPTION
## Summary
- add service utilities for item availability and customization management
- expose new /items endpoints for CRUD and customization operations
- register item endpoints in the v1 router

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840dce6ae4483339a7de5716f04495b