### PR TITLE
Implement menu and category management endpoints

### DIFF
--- a/app/api/v1/endpoints/categories.py
+++ b/app/api/v1/endpoints/categories.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter, HTTPException
+
+from app.schema import category as category_schema
+from app.services import category as category_service
+from app.services import item as item_service
+
+router = APIRouter()
+
+@router.post("/")
+async def create_category(data: category_schema.CategoryCreate):
+    try:
+        created = await category_service.create_category(data)
+        return created.to_response()
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=str(error))
+
+@router.get("/{category_id}")
+async def get_category(category_id: str):
+    category = await category_service.get_category(category_id)
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return category.to_response()
+
+@router.put("/{category_id}")
+async def update_category(category_id: str, data: category_schema.CategoryUpdate):
+    updated = await category_service.update_category(category_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return updated.to_response()
+
+@router.delete("/{category_id}")
+async def delete_category(category_id: str):
+    result = await category_service.delete_category(category_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return True
+
+@router.put("/{category_id}/availability")
+async def switch_category_availability(category_id: str, is_active: bool):
+    updated = await category_service.update_category_availability(category_id, is_active)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return updated.to_response()
+
+@router.get("/{category_id}/items")
+async def list_category_items(category_id: str):
+    items = await item_service.list_items_by_category(category_id)
+    return [i.to_response() for i in items]
+
+@router.post("/{category_id}/items/{item_id}")
+async def add_item(category_id: str, item_id: str):
+    try:
+        category = await category_service.add_item_to_category(category_id, item_id)
+        return category.to_response()
+    except Exception as error:
+        raise HTTPException(status_code=404, detail=str(error))
+
+@router.delete("/{category_id}/items/{item_id}")
+async def remove_item(category_id: str, item_id: str):
+    try:
+        category = await category_service.remove_item_from_category(category_id, item_id)
+        return category.to_response()
+    except Exception as error:
+        raise HTTPException(status_code=404, detail=str(error))
+
+@router.get("/menu/{menu_id}")
+async def list_menu_categories(menu_id: str):
+    categories = await category_service.list_categories_for_menu(menu_id)
+    return [c.to_response() for c in categories]
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_restaurant_categories(restaurant_id: str):
+    categories = await category_service.list_categories_for_restaurant(restaurant_id)
+    return [c.to_response() for c in categories]
+
+@router.get("/slug/{slug}")
+async def get_category_by_slug(slug: str):
+    category = await category_service.get_category_by_slug(slug)
+    if not category:
+        raise HTTPException(status_code=404, detail="Category not found")
+    return category.to_response()

--- a/app/api/v1/endpoints/menus.py
+++ b/app/api/v1/endpoints/menus.py
@@ -2,6 +2,8 @@ from fastapi import APIRouter, HTTPException
 
 from app.schema import menu as menu_schema
 from app.services import menu as menu_service
+from app.services import category as category_service
+from app.services import item as item_service
 
 router = APIRouter()
 
@@ -19,6 +21,20 @@ async def delete_menu(menu_id: str):
     if not result:
         raise HTTPException(status_code=404, detail="Menu not found")
     return True
+
+@router.put("/{menu_id}")
+async def update_menu(menu_id: str, data: menu_schema.MenuUpdate):
+    updated = await menu_service.update_menu(menu_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Menu not found")
+    return updated.to_response()
+
+@router.put("/{menu_id}/preferences")
+async def update_menu_preferences(menu_id: str, preferences: menu_schema.MenuPreferences):
+    updated = await menu_service.update_menu(menu_id, menu_schema.MenuUpdate(preferences=preferences))
+    if not updated:
+        raise HTTPException(status_code=404, detail="Menu not found")
+    return updated.to_response()
 
 @router.put("/{menu_id}/status")
 async def update_menu_status(menu_id: str, is_active: bool):
@@ -38,3 +54,13 @@ async def get_menu(menu_id: str):
 async def list_restaurant_menus(restaurant_id: str):
     menus = await menu_service.list_menus(restaurant_id)
     return [m.to_response() for m in menus]
+
+@router.get("/{menu_id}/categories")
+async def list_menu_categories(menu_id: str):
+    categories = await category_service.list_categories_for_menu(menu_id)
+    return [c.to_response() for c in categories]
+
+@router.get("/{menu_id}/items")
+async def list_menu_items(menu_id: str):
+    items = await item_service.list_items_by_menu(menu_id)
+    return [i.to_response() for i in items]

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -9,6 +9,8 @@ from app.api.v1.endpoints.blog import router as blog_router
 from app.api.v1.endpoints.bookings import router as booking_router
 from app.api.v1.endpoints.insights import router as insights_router
 from app.api.v1.endpoints.items import router as items_router
+from app.api.v1.endpoints.menus import router as menus_router
+from app.api.v1.endpoints.categories import router as categories_router
 
 
 router = APIRouter()
@@ -23,3 +25,5 @@ router.include_router(analytics_router, prefix="/analytics", tags=["Analytics"])
 router.include_router(booking_router, prefix="/bookings", tags=["Bookings"])
 router.include_router(insights_router, prefix="/insights", tags=["AI Insights"])
 router.include_router(items_router, prefix="/items", tags=["Items"])
+router.include_router(menus_router, prefix="/menus", tags=["Menus"])
+router.include_router(categories_router, prefix="/categories", tags=["Categories"])

--- a/app/services/category.py
+++ b/app/services/category.py
@@ -15,6 +15,19 @@ async def update_category(category_id: str, data: category_schema.CategoryUpdate
 async def delete_category(category_id: str):
     return await category_model.delete(category_id)
 
+async def get_category(category_id: str):
+    """Retrieve a category by its id."""
+    return await category_model.get(category_id)
+
+async def list_categories_for_menu(menu_id: str):
+    """List all active categories that belong to a menu."""
+    filters = {"menuId": menu_id, "isActive": True}
+    return await category_model.get_by_fields(filters)
+
+async def update_category_availability(category_id: str, is_active: bool):
+    """Switch the availability flag of a category."""
+    return await category_model.update(category_id, {"isActive": is_active})
+
 async def list_categories_for_restaurant(restaurant_id: str):
     filters = {"restaurantId": restaurant_id, "isActive": True}
     return await category_model.get_by_fields(filters)

--- a/app/services/item.py
+++ b/app/services/item.py
@@ -1,4 +1,5 @@
 from app.models.item import ItemModel
+from app.models.category import CategoryModel
 from app.utils.slug import generate_unique_slug
 from app.schema import item as item_schema
 
@@ -119,4 +120,14 @@ async def delete_customization_option(item_id: str, customization_index: int, op
 
     item.customizations[customization_index].options.pop(option_index)
     return await item_model.update(item_id, {"customizations": _serialize_customizations(item.customizations)})
+
+
+async def list_items_by_menu(menu_id: str):
+    """List all available items for a specific menu."""
+    categories = await CategoryModel().get_by_fields({"menuId": menu_id, "isActive": True})
+    all_items: list[item_schema.ItemDocument] = []
+    for category in categories:
+        items = await item_model.get_by_fields({"categoryId": str(category.id), "isAvailable": True})
+        all_items.extend(items)
+    return all_items
 


### PR DESCRIPTION
## Summary
- create `categories` endpoints with CRUD, availability and item management
- expand `menus` endpoints with update, preferences and menu fetch helpers
- hook new routers into the v1 API router
- extend services for categories and items to support new operations

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6840e07aed1c8333bc4baf367439ffa2