### PR TITLE
Add menu duplication endpoint

### DIFF
--- a/app/api/v1/endpoints/menus.py
+++ b/app/api/v1/endpoints/menus.py
@@ -92,3 +92,13 @@ async def list_menu_items_by_slug(menu_slug: str):
             detail=str(error),
             status_code=400
         )
+
+
+@router.post("/copy/{menu_slug}")
+async def copy_menu(menu_slug: str, restaurant_id: str):
+    """Create a copy of a menu, its categories and items."""
+    try:
+        menu = await menu_service.copy_menu_by_slug(menu_slug, restaurant_id)
+        return menu.to_response()
+    except Exception as error:
+        raise HTTPException(status_code=400, detail=str(error))


### PR DESCRIPTION
## Summary
- copy menus by slug with new categories and items
- expose new copy endpoint for menus

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68415548bd6c8333906da42dce09a851