### PR TITLE
Add table endpoints

### DIFF
--- a/app/api/v1/endpoints/tables.py
+++ b/app/api/v1/endpoints/tables.py
@@ -1,0 +1,62 @@
+from fastapi import APIRouter, HTTPException
+from typing import Optional
+
+from app.schema import table as table_schema
+from app.services import table as table_service
+
+router = APIRouter()
+
+
+@router.post("/")
+async def create_table(data: table_schema.TableCreate):
+    try:
+        table = await table_service.create_table(data)
+        return table.to_response()
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=str(error))
+
+
+@router.get("/{table_id}")
+async def get_table(table_id: str):
+    table = await table_service.get_table(table_id)
+    if not table:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return table.to_response()
+
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_tables(restaurant_id: str):
+    tables = await table_service.list_tables_for_restaurant(restaurant_id)
+    return [t.to_response() for t in tables]
+
+
+@router.put("/{table_id}")
+async def update_table(table_id: str, data: table_schema.TableUpdate):
+    updated = await table_service.update_table(table_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return updated.to_response()
+
+
+@router.delete("/{table_id}")
+async def delete_table(table_id: str):
+    result = await table_service.delete_table(table_id)
+    if not result:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return True
+
+
+@router.put("/{table_id}/status")
+async def update_table_status(table_id: str, is_active: bool):
+    table = await table_service.update_table_status(table_id, is_active)
+    if not table:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return table.to_response()
+
+
+@router.put("/{table_id}/session")
+async def update_table_session(table_id: str, session_id: Optional[str] = None):
+    table = await table_service.update_table_session(table_id, session_id)
+    if not table:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return table.to_response()

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -11,6 +11,7 @@ from app.api.v1.endpoints.insights import router as insights_router
 from app.api.v1.endpoints.items import router as items_router
 from app.api.v1.endpoints.menus import router as menus_router
 from app.api.v1.endpoints.categories import router as categories_router
+from app.api.v1.endpoints.tables import router as tables_router
 
 
 router = APIRouter()
@@ -27,3 +28,4 @@ router.include_router(insights_router, prefix="/insights", tags=["AI Insights"])
 router.include_router(items_router, prefix="/items", tags=["Items"])
 router.include_router(menus_router, prefix="/menus", tags=["Menus"])
 router.include_router(categories_router, prefix="/categories", tags=["Categories"])
+router.include_router(tables_router, prefix="/tables", tags=["Tables"])

--- a/app/models/table.py
+++ b/app/models/table.py
@@ -1,0 +1,6 @@
+from app.db.crud import MongoCrud
+from app.schema import table as table_schema
+
+class TableModel(MongoCrud[table_schema.TableDocument]):
+    def __init__(self):
+        super().__init__(table_schema.TableDocument)

--- a/app/services/table.py
+++ b/app/services/table.py
@@ -1,0 +1,53 @@
+from typing import Optional, List
+
+from app.models.table import TableModel
+from app.models.restaurant import RestaurantModel
+from app.schema import table as table_schema
+
+
+table_model = TableModel()
+restaurant_model = RestaurantModel()
+
+
+async def create_table(data: table_schema.TableCreate) -> table_schema.TableDocument:
+    payload = data.model_dump(by_alias=False)
+    table = await table_model.create(payload)
+    restaurant = await restaurant_model.get(data.restaurant_id)
+    if restaurant:
+        table_ids = restaurant.table_ids or []
+        table_ids.append(str(table.id))
+        await restaurant_model.update(str(restaurant.id), {"tableIds": table_ids})
+    return table
+
+
+async def get_table(table_id: str) -> Optional[table_schema.TableDocument]:
+    return await table_model.get(table_id)
+
+
+async def list_tables_for_restaurant(restaurant_id: str) -> List[table_schema.TableDocument]:
+    return await table_model.get_by_fields({"restaurantId": restaurant_id})
+
+
+async def update_table(table_id: str, data: table_schema.TableUpdate) -> Optional[table_schema.TableDocument]:
+    return await table_model.update(table_id, data.model_dump(exclude_none=True, by_alias=True))
+
+
+async def delete_table(table_id: str) -> bool:
+    table = await table_model.get(table_id)
+    if not table:
+        return False
+
+    restaurant = await restaurant_model.get(table.restaurant_id)
+    if restaurant and table_id in restaurant.table_ids:
+        ids = [tid for tid in restaurant.table_ids if tid != table_id]
+        await restaurant_model.update(str(restaurant.id), {"tableIds": ids})
+
+    return await table_model.delete(table_id)
+
+
+async def update_table_status(table_id: str, is_active: bool) -> Optional[table_schema.TableDocument]:
+    return await table_model.update(table_id, {"isActive": is_active})
+
+
+async def update_table_session(table_id: str, session_id: Optional[str]) -> Optional[table_schema.TableDocument]:
+    return await table_model.update(table_id, {"currentSessionId": session_id})


### PR DESCRIPTION
## Summary
- implement TableModel
- implement table service functions
- expose table API endpoints for CRUD and status updates
- register table router

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842328e3fd4833399e1e9980629fb61