### PR TITLE
Add role management endpoints

### DIFF
--- a/app/api/v1/endpoints/roles.py
+++ b/app/api/v1/endpoints/roles.py
@@ -1,0 +1,39 @@
+from fastapi import APIRouter, HTTPException
+from app.schema import role as role_schema
+from app.services import roles as role_service
+
+router = APIRouter()
+
+@router.post("/")
+async def create_role(data: role_schema.RoleCreate):
+    try:
+        role = await role_service.create_role(data)
+        return role.to_response()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+@router.get("/{role_id}")
+async def get_role(role_id: str):
+    role = await role_service.get_role(role_id)
+    if not role:
+        raise HTTPException(status_code=404, detail="Role not found")
+    return role.to_response()
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_restaurant_roles(restaurant_id: str):
+    roles = await role_service.list_roles(restaurant_id)
+    return [r.to_response() for r in roles]
+
+@router.put("/{role_id}")
+async def update_role(role_id: str, data: role_schema.RoleUpdate):
+    updated = await role_service.update_role(role_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Role not found")
+    return updated.to_response()
+
+@router.delete("/{role_id}")
+async def deactivate_role(role_id: str):
+    updated = await role_service.deactivate_role(role_id)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Role not found")
+    return True

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -13,6 +13,7 @@ from app.api.v1.endpoints.menus import router as menus_router
 from app.api.v1.endpoints.categories import router as categories_router
 from app.api.v1.endpoints.tables import router as tables_router
 from app.api.v1.endpoints.table_sessions import router as table_sessions_router
+from app.api.v1.endpoints.roles import router as roles_router
 
 
 router = APIRouter()
@@ -31,3 +32,4 @@ router.include_router(menus_router, prefix="/menus", tags=["Menus"])
 router.include_router(categories_router, prefix="/categories", tags=["Categories"])
 router.include_router(tables_router, prefix="/tables", tags=["Tables"])
 router.include_router(table_sessions_router, prefix="/sessions", tags=["Table Sessions"])
+router.include_router(roles_router, prefix="/roles", tags=["Roles"])

--- a/app/schema/role.py
+++ b/app/schema/role.py
@@ -50,7 +50,13 @@ class Role(RoleBase, DocumentId):
     }
 
 class RoleDocument(Document, Role):
+    """Database representation for roles."""
+
+    def to_response(self) -> "Role":
+        """Convert document to API response model."""
+        return Role(**self.model_dump(by_alias=True))
 
     class Settings:
         name = "roles"
         bson_encoders = {ObjectId: str}
+


### PR DESCRIPTION
## Summary
- add database response conversion for role documents
- create role management API routes
- register the new role routes

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6842b69927a083338c0d1addf7a82e6d