### PR TITLE
Add invitation endpoints and role deletion

### DIFF
--- a/app/api/v1/endpoints/invitation.py
+++ b/app/api/v1/endpoints/invitation.py
@@ -1,19 +1,35 @@
 from typing import List
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import EmailStr
+
 from app.schema import invitation as invitation_schema
 from app.models.invitation import InvitationModel
-
+from app.services import invitation as invitation_service
 
 router = APIRouter()
 invitation_model = InvitationModel()
 
 
+@router.post("/", response_model=invitation_schema.Invitation)
+async def create_invitation(data: invitation_schema.InvitationCreate):
+    try:
+        invitation = await invitation_service.create_invitation(data)
+        return invitation.to_response()
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.delete("/{invitation_id}")
+async def delete_invitation(invitation_id: str):
+    deleted = await invitation_service.delete_invitation(invitation_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Invitation not found")
+    return True
+
+
 @router.get("/{email}/email", response_model=List[invitation_schema.Invitation])
 async def get_user_invitations(email: EmailStr):
-    documents = await invitation_model.get_by_fields({
-        "email": email
-    })
-    invitations = list(map(lambda invitation: invitation.to_response, documents))
+    documents = await invitation_model.get_by_fields({"email": email})
+    invitations = [inv.to_response() for inv in documents]
     return invitations

--- a/app/api/v1/endpoints/roles.py
+++ b/app/api/v1/endpoints/roles.py
@@ -1,4 +1,5 @@
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Depends
+from app.utils.auth import get_current_user
 from app.schema import role as role_schema
 from app.services import roles as role_service
 
@@ -37,3 +38,14 @@ async def deactivate_role(role_id: str):
     if not updated:
         raise HTTPException(status_code=404, detail="Role not found")
     return True
+
+
+@router.delete("/hard/{role_id}")
+async def delete_role(role_id: str, uid: str = Depends(get_current_user)):
+    try:
+        deleted = await role_service.delete_role(role_id, uid)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Role not found")
+        return True
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))


### PR DESCRIPTION
## Summary
- allow creating and deleting restaurant invitations
- add role deletion logic with fallback to a `no_role` role
- expose API route for hard deleting roles

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68439d0c1564833390b050ce58ece667