### PR TITLE
Add membership management endpoints

### DIFF
--- a/app/api/v1/endpoints/memberships.py
+++ b/app/api/v1/endpoints/memberships.py
@@ -1,0 +1,38 @@
+from fastapi import APIRouter, HTTPException
+
+from app.services import membership as membership_service
+from app.schema import membership as membership_schema
+
+router = APIRouter()
+
+@router.post("/")
+async def create_membership(data: membership_schema.MembershipCreate):
+    try:
+        user = await membership_service.add_membership(data.user_id, data.role_id)
+        return user.to_response()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.put("/{user_id}/restaurant/{restaurant_id}")
+async def update_membership(user_id: str, restaurant_id: str, data: membership_schema.MembershipUpdate):
+    try:
+        user = await membership_service.update_membership_role(user_id, restaurant_id, data.role_id)
+        return user.to_response()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.delete("/{user_id}/restaurant/{restaurant_id}")
+async def deactivate_membership(user_id: str, restaurant_id: str):
+    try:
+        user = await membership_service.deactivate_membership(user_id, restaurant_id)
+        return user.to_response()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+@router.get("/{user_id}")
+async def list_user_memberships(user_id: str):
+    try:
+        memberships = await membership_service.list_user_memberships(user_id)
+        return [m.model_dump(by_alias=True) for m in memberships]
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -14,6 +14,7 @@ from app.api.v1.endpoints.categories import router as categories_router
 from app.api.v1.endpoints.tables import router as tables_router
 from app.api.v1.endpoints.table_sessions import router as table_sessions_router
 from app.api.v1.endpoints.roles import router as roles_router
+from app.api.v1.endpoints.memberships import router as memberships_router
 
 
 router = APIRouter()
@@ -33,3 +34,4 @@ router.include_router(categories_router, prefix="/categories", tags=["Categories
 router.include_router(tables_router, prefix="/tables", tags=["Tables"])
 router.include_router(table_sessions_router, prefix="/sessions", tags=["Table Sessions"])
 router.include_router(roles_router, prefix="/roles", tags=["Roles"])
+router.include_router(memberships_router, prefix="/memberships", tags=["Memberships"])

--- a/app/schema/membership.py
+++ b/app/schema/membership.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel, Field
+
+class MembershipCreate(BaseModel):
+    user_id: str = Field(..., alias="userId")
+    role_id: str = Field(..., alias="roleId")
+
+class MembershipUpdate(BaseModel):
+    role_id: str = Field(..., alias="roleId")

--- a/app/services/membership.py
+++ b/app/services/membership.py
@@ -1,0 +1,90 @@
+from typing import List
+
+from app.models.user import UserModel
+from app.models.role import RoleModel
+from app.schema import user as user_schema
+
+user_model = UserModel()
+role_model = RoleModel()
+
+async def add_membership(user_id: str, role_id: str) -> user_schema.UserDocument:
+    user = await user_model.get(user_id)
+    if not user:
+        raise Exception("User not found")
+
+    role = await role_model.get(role_id)
+    if not role:
+        raise Exception("Role not found")
+
+    existing_role_ids = [m.role_id for m in user.memberships]
+    roles = await role_model.get_many(existing_role_ids) if existing_role_ids else []
+    role_map = {str(r.id): r for r in roles}
+
+    # Check if membership for the same restaurant exists
+    for membership in user.memberships:
+        m_role = role_map.get(membership.role_id)
+        if m_role and m_role.restaurant_id == role.restaurant_id:
+            if membership.is_active:
+                raise Exception("User already member of this restaurant")
+            membership.is_active = True
+            membership.role_id = role_id
+            await user_model.update(str(user.id), {"memberships": [m.model_dump(by_alias=True) for m in user.memberships]})
+            return await user_model.get(user_id)
+
+    user.memberships.append(user_schema.UserRestaurantMembership(roleId=role_id, isActive=True))
+    await user_model.update(str(user.id), {"memberships": [m.model_dump(by_alias=True) for m in user.memberships]})
+    return await user_model.get(user_id)
+
+async def update_membership_role(user_id: str, restaurant_id: str, new_role_id: str) -> user_schema.UserDocument:
+    user = await user_model.get(user_id)
+    if not user:
+        raise Exception("User not found")
+
+    new_role = await role_model.get(new_role_id)
+    if not new_role or new_role.restaurant_id != restaurant_id:
+        raise Exception("Role not found for restaurant")
+
+    existing_role_ids = [m.role_id for m in user.memberships]
+    roles = await role_model.get_many(existing_role_ids) if existing_role_ids else []
+    role_map = {str(r.id): r for r in roles}
+
+    updated = False
+    for membership in user.memberships:
+        m_role = role_map.get(membership.role_id)
+        if m_role and m_role.restaurant_id == restaurant_id and membership.is_active:
+            membership.role_id = new_role_id
+            updated = True
+    if not updated:
+        raise Exception("Membership not found for restaurant")
+
+    await user_model.update(str(user.id), {"memberships": [m.model_dump(by_alias=True) for m in user.memberships]})
+    return await user_model.get(user_id)
+
+async def deactivate_membership(user_id: str, restaurant_id: str) -> user_schema.UserDocument:
+    user = await user_model.get(user_id)
+    if not user:
+        raise Exception("User not found")
+
+    existing_role_ids = [m.role_id for m in user.memberships]
+    roles = await role_model.get_many(existing_role_ids) if existing_role_ids else []
+    role_map = {str(r.id): r for r in roles}
+
+    updated = False
+    for membership in user.memberships:
+        m_role = role_map.get(membership.role_id)
+        if m_role and m_role.restaurant_id == restaurant_id and membership.is_active:
+            membership.is_active = False
+            updated = True
+    if not updated:
+        raise Exception("Membership not found for restaurant")
+
+    await user_model.update(str(user.id), {"memberships": [m.model_dump(by_alias=True) for m in user.memberships]})
+    if user.current_restaurant_id == restaurant_id:
+        await user_model.update(str(user.id), {"currentRestaurantId": None})
+    return await user_model.get(user_id)
+
+async def list_user_memberships(user_id: str) -> List[user_schema.UserRestaurantMembership]:
+    user = await user_model.get(user_id)
+    if not user:
+        raise Exception("User not found")
+    return user.memberships


### PR DESCRIPTION
## Summary
- create membership schemas
- implement membership service for users
- expose membership APIs
- register new routes

## Testing
- `python -m compileall -q app`

------
https://chatgpt.com/codex/tasks/task_e_6848cdadb6a48333808659cff1595932