### PR TITLE
Add restaurant slug and current menu endpoints

### DIFF
--- a/app/api/v1/endpoints/restaurants.py
+++ b/app/api/v1/endpoints/restaurants.py
@@ -11,12 +11,14 @@ from app.services.restaurant import (
     create_restaurant,
     deactivate_restaurant,
     get_restaurant,
+    get_restaurant_by_slug,
     update_restaurant,
     delete_restaurant,
     get_restaurants,
     get_active_restaurants,
     restaurant_model,
     change_current_menu,
+    get_current_menu,
 )
 from app.schema import restaurant as restaurant_schema
 from app.services.roles import create_default_roles_for_restaurant
@@ -250,6 +252,14 @@ async def get_single_restaurant(restaurant_id: str):
     return await get_restaurant(restaurant_id)
 
 
+@router.get("/slug/{slug}")
+async def get_restaurant_by_slug_endpoint(slug: str):
+    restaurant = await get_restaurant_by_slug(slug)
+    if not restaurant:
+        raise HTTPException(status_code=404, detail="Restaurant not found")
+    return restaurant.to_response()
+
+
 @router.put("/{restaurant_id}")
 async def update_existing_restaurant(restaurant_id: str, data: restaurant_schema.RestaurantUpdate):
     return await update_restaurant(restaurant_id, data)
@@ -258,6 +268,14 @@ async def update_existing_restaurant(restaurant_id: str, data: restaurant_schema
 @router.put("/{restaurant_id}/current-menu/{menu_id}")
 async def change_current_menu_endpoint(restaurant_id: str, menu_id: str):
     return await change_current_menu(restaurant_id, menu_id)
+
+
+@router.get("/{restaurant_id}/current-menu")
+async def get_current_menu_endpoint(restaurant_id: str):
+    menu = await get_current_menu(restaurant_id)
+    if not menu:
+        raise HTTPException(status_code=404, detail="Current menu not found")
+    return menu.to_response()
 
 
 @router.delete("/{restaurant_id}", dependencies=[Depends(admin_required)])

--- a/app/services/restaurant.py
+++ b/app/services/restaurant.py
@@ -1,11 +1,14 @@
 from fastapi import HTTPException
 
+from app.models.menu import MenuModel
+
 from app.models.restaurant import RestaurantModel
 from app.schema import restaurant as restaurant_schema
 from app.utils.slug import generate_unique_slug
 
 
 restaurant_model = RestaurantModel()
+menu_model = MenuModel()
 
 async def create_restaurant(data: restaurant_schema.RestaurantCreate):
     try:
@@ -41,6 +44,17 @@ async def get_restaurant(restaurant_id: str):
 
 async def get_restaurant_by_slug(slug: str):
     return await restaurant_model.get_by_slug(slug)
+
+async def get_current_menu(restaurant_id: str):
+    restaurant = await restaurant_model.get(restaurant_id)
+    if not restaurant:
+        raise HTTPException(status_code=404, detail="Restaurant not found")
+
+    if not restaurant.current_menu_id:
+        return None
+
+    menu = await menu_model.get(restaurant.current_menu_id)
+    return menu
 
 async def change_current_menu(restaurant_id: str, menu_id: str) -> bool:
     restaurant = await restaurant_model.get(restaurant_id)


### PR DESCRIPTION
## Summary
- add menu_model and get_current_menu service method
- expose `/slug/{slug}` and `/current-menu` routes

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6849655f97408333b0ea1090e087c78b