### PR TITLE
Add endpoint to list active items by category

### DIFF
--- a/app/api/v1/endpoints/items.py
+++ b/app/api/v1/endpoints/items.py
@@ -112,3 +112,10 @@ async def delete_customization_option(item_id: str, c_index: int, o_index: int):
         raise HTTPException(status_code=404, detail="Item or option not found")
     return updated.to_response()
 
+
+@router.get("/category/{category_id}")
+async def list_active_items(category_id: str):
+    """Return all active items that belong to the given category."""
+    items = await item_service.list_items_by_category(category_id)
+    return [i.to_response() for i in items]
+


### PR DESCRIPTION
## Summary
- expose `/items/category/{category_id}` to return items that belong to a category and are available

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68496bb59a1083338bdb415600aa98c5