### PR TITLE
Add endpoint for active table session by number

### DIFF
--- a/app/api/v1/endpoints/table_sessions.py
+++ b/app/api/v1/endpoints/table_sessions.py
@@ -4,6 +4,13 @@ from app.schema.table_session import TableSession, TableSessionStatus
 
 router = APIRouter()
 
+@router.get("/active/{restaurant_id}/{table_number}")
+async def get_active_session_by_number(restaurant_id: str, table_number: int):
+    session = await session_service.get_active_session_for_restaurant_table(restaurant_id, table_number)
+    if not session:
+        raise HTTPException(status_code=404, detail="Active session not found")
+    return session.to_response()
+
 @router.get("/active/{table_id}")
 async def get_active_session(table_id: str):
     session = await session_service.get_active_session_for_table(table_id)

--- a/app/services/table.py
+++ b/app/services/table.py
@@ -55,3 +55,12 @@ async def update_table_status(table_id: str, is_active: bool) -> Optional[table_
 
 async def update_table_session(table_id: str, session_id: Optional[str]) -> Optional[table_schema.TableDocument]:
     return await table_model.update(table_id, {"currentSessionId": session_id})
+
+
+async def get_table_by_restaurant_and_number(restaurant_id: str, number: int) -> Optional[table_schema.TableDocument]:
+    """Retrieve a table by restaurant id and table number."""
+    filters = {"restaurantId": restaurant_id, "number": number}
+    tables = await table_model.get_by_fields(filters, limit=1)
+    if tables:
+        return tables[0]
+    return None

--- a/app/services/table_session.py
+++ b/app/services/table_session.py
@@ -39,6 +39,16 @@ async def get_active_session_for_table(table_id: str):
         return sessions[0]
     return None
 
+
+async def get_active_session_for_restaurant_table(restaurant_id: str, table_number: int):
+    """Return the active session given restaurant id and table number."""
+    from app.services import table as table_service  # Imported here to avoid circular imports
+
+    table = await table_service.get_table_by_restaurant_and_number(restaurant_id, table_number)
+    if not table:
+        return None
+    return await get_active_session_for_table(str(table.id))
+
 async def close_table_session(session_id: str, cancelled: bool = False) -> TableSessionDocument:
     """Close or cancel a session and create the next one."""
     session = await session_model.get(session_id)


### PR DESCRIPTION
## Summary
- support finding tables by restaurant and number
- expose service to retrieve active sessions for restaurant table numbers
- add `/sessions/active/{restaurant_id}/{table_number}` endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849b8971b5883338743ce662d596bac