### PR TITLE
Update order creation to link session

### DIFF
--- a/app/api/v1/endpoints/orders.py
+++ b/app/api/v1/endpoints/orders.py
@@ -7,9 +7,13 @@ router = APIRouter()
 
 
 @router.post("/")
-async def create_order(data: order_schema.OrderCreate):
+async def create_order(data: order_schema.OrderCreate, session_id: str | None = None):
+    """Create a new order and append it to the related session."""
     try:
-        order = await order_service.place_order(data.model_dump(by_alias=True))
+        payload = data.model_dump(by_alias=True)
+        if session_id:
+            payload["sessionId"] = session_id
+        order = await order_service.place_order(payload)
         return order.to_response()
     except Exception as error:
         raise HTTPException(status_code=500, detail=str(error))

--- a/app/services/order.py
+++ b/app/services/order.py
@@ -1,11 +1,17 @@
 from app.models.order import OrderModel
 from app.schema import order as order_schema
+from app.services import table_session as table_session_service
 
 order_model = OrderModel()
 
 
 async def place_order(data: dict) -> order_schema.OrderDocument:
-    return await order_model.create(data)
+    """Create a new order and attach it to the related table session."""
+    order = await order_model.create(data)
+    session_id = data.get("sessionId")
+    if session_id:
+        await table_session_service.add_order_to_session(session_id, str(order.id))
+    return order
 
 
 async def get_order(order_id: str) -> order_schema.OrderDocument | None:

--- a/app/services/table_session.py
+++ b/app/services/table_session.py
@@ -49,6 +49,19 @@ async def get_active_session_for_restaurant_table(restaurant_id: str, table_numb
         return None
     return await get_active_session_for_table(str(table.id))
 
+
+async def add_order_to_session(session_id: str, order_id: str) -> TableSessionDocument | None:
+    """Append an order ID to a table session's order list."""
+    session = await session_model.get(session_id)
+    if not session:
+        return None
+
+    if order_id not in session.orders:
+        session.orders.append(order_id)
+        return await session_model.update(session_id, {"orders": session.orders})
+
+    return session
+
 async def close_table_session(session_id: str, cancelled: bool = False) -> TableSessionDocument:
     """Close or cancel a session and create the next one."""
     session = await session_model.get(session_id)


### PR DESCRIPTION
## Summary
- add optional `session_id` parameter to orders API
- update order service to append new orders to table sessions
- implement helper in table session service to add order IDs

## Testing
- `ruff check app/services/order.py`
- `ruff check app/services/table_session.py`
- `ruff check app/api/v1/endpoints/orders.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6849bd8b3d248333bed2ed25a23abdc9