### PR TITLE
Add recent orders endpoint

### DIFF
--- a/app/api/v1/endpoints/orders.py
+++ b/app/api/v1/endpoints/orders.py
@@ -79,6 +79,17 @@ async def list_restaurant_orders(restaurant_id: str):
     return [o.to_response() for o in orders]
 
 
+@router.get("/restaurant/{restaurant_id}/recent")
+async def list_recent_restaurant_orders(
+    restaurant_id: str, hours: int = 24
+):
+    """Return orders from the last ``hours`` for the given restaurant."""
+    orders = await order_service.list_recent_orders_for_restaurant(
+        restaurant_id, hours
+    )
+    return [o.to_response() for o in orders]
+
+
 @router.get("/status/{prep_status}")
 async def list_orders_by_status(prep_status: order_schema.OrderPrepStatus):
     orders = await order_service.list_orders_by_prep_status(prep_status)


### PR DESCRIPTION
## Summary
- query orders from the last X hours
- expose `GET /orders/restaurant/{restaurant_id}/recent` endpoint

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a02affee4833385296e67a6a9771e