### PR TITLE
Handle missing table sessions

### DIFF
--- a/app/services/table_session.py
+++ b/app/services/table_session.py
@@ -28,26 +28,58 @@ async def create_session_for_table(table_id: str, restaurant_id: str) -> TableSe
     await table_service.update_table_session(table_id, str(session.id))
     return session
 
-async def get_active_session_for_table(table_id: str):
-    filters = {
-        "tableId": table_id,
-        "status": "active"
-    }
+async def get_active_session_for_table(
+    table_id: str,
+    *,
+    create_if_missing: bool = False,
+    restaurant_id: str | None = None
+) -> TableSessionDocument | None:
+    """Return the active session for a table.
+
+    If ``create_if_missing`` is True and no active session exists, a new one will
+    be created and linked to the table.
+    """
+    filters = {"tableId": table_id, "status": "active"}
     sessions = await session_model.get_by_fields(filters, limit=1)
 
     if sessions:
         return sessions[0]
+
+    if create_if_missing:
+        if restaurant_id is None:
+            from app.services import table as table_service  # avoid circular import
+            table = await table_service.get_table(table_id)
+            if not table:
+                return None
+            restaurant_id = table.restaurant_id
+
+        return await create_session_for_table(table_id, restaurant_id)
+
     return None
 
 
-async def get_active_session_for_restaurant_table(restaurant_id: str, table_number: int):
-    """Return the active session given restaurant id and table number."""
+async def get_active_session_for_restaurant_table(
+    restaurant_id: str,
+    table_number: int,
+    *,
+    create_if_missing: bool = False
+) -> TableSessionDocument | None:
+    """Return the active session for a restaurant table.
+
+    When ``create_if_missing`` is True, a new active session will be created if
+    none exists.
+    """
     from app.services import table as table_service  # Imported here to avoid circular imports
 
     table = await table_service.get_table_by_restaurant_and_number(restaurant_id, table_number)
     if not table:
         return None
-    return await get_active_session_for_table(str(table.id))
+
+    return await get_active_session_for_table(
+        str(table.id),
+        create_if_missing=create_if_missing,
+        restaurant_id=restaurant_id,
+    )
 
 
 async def add_order_to_session(session_id: str, order_id: str) -> TableSessionDocument | None:


### PR DESCRIPTION
## Summary
- ensure an active session exists when placing an order
- allow table session lookups to auto-create a session when not found

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684a28447fc883338c7c30686946c378