### PR TITLE
Expand booking endpoints

### DIFF
--- a/app/api/v1/endpoints/bookings.py
+++ b/app/api/v1/endpoints/bookings.py
@@ -1,29 +1,72 @@
-from datetime import datetime, timedelta
+from datetime import datetime
 
-from beanie.odm.operators.find.comparison import Eq, GTE
-from beanie.odm.operators.find.logical import And
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 
-from app.schema.bookings import BookingDocument
-
+from app.schema.bookings import BookingCreate, BookingUpdate
+from app.services import booking as booking_service
 
 router = APIRouter()
 
-@router.get("/upcoming/{restaurant_id}")
-async def get_restaurant_upcoming_bookings(
-    restaurant_id: str
-):
+
+@router.post("/")
+async def create_booking(data: BookingCreate):
     try:
-        day = datetime.now()
-        day = day.replace(hour=day.hour - 1, minute=0, second=0, microsecond=0)
-
-        bookings = await BookingDocument.find(
-            And(
-                Eq(BookingDocument.restaurant_id, restaurant_id),
-                GTE(BookingDocument.start_time, day),
-            )
-        ).to_list()
-
-        return bookings
+        booking = await booking_service.create_booking(data.model_dump(by_alias=True))
+        return booking.to_response()
     except Exception as error:
-        print(error)
+        raise HTTPException(status_code=400, detail=str(error))
+
+
+@router.get("/{booking_id}")
+async def get_booking(booking_id: str):
+    booking = await booking_service.get_booking(booking_id)
+    if not booking:
+        raise HTTPException(status_code=404, detail="Booking not found")
+    return booking.to_response()
+
+
+@router.put("/{booking_id}")
+async def update_booking(booking_id: str, data: BookingUpdate):
+    updated = await booking_service.update_booking(booking_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Booking not found")
+    return updated.to_response()
+
+
+@router.delete("/{booking_id}")
+async def delete_booking(booking_id: str):
+    deleted = await booking_service.delete_booking(booking_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Booking not found")
+    return True
+
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_restaurant_bookings(restaurant_id: str):
+    bookings = await booking_service.list_bookings_for_restaurant(restaurant_id)
+    return [b.to_response() for b in bookings]
+
+
+@router.get("/table/{table_id}")
+async def list_table_bookings(table_id: str):
+    bookings = await booking_service.list_bookings_for_table(table_id)
+    return [b.to_response() for b in bookings]
+
+
+@router.get("/upcoming/{restaurant_id}")
+async def get_restaurant_upcoming_bookings(restaurant_id: str):
+    try:
+        bookings = await booking_service.list_upcoming_bookings(restaurant_id)
+        return [b.to_response() for b in bookings]
+    except Exception as error:
+        raise HTTPException(status_code=500, detail=str(error))
+
+
+@router.get("/date/{restaurant_id}/{day}")
+async def get_bookings_by_date(restaurant_id: str, day: str):
+    try:
+        date = datetime.fromisoformat(day)
+        bookings = await booking_service.list_bookings_for_date(restaurant_id, date)
+        return [b.to_response() for b in bookings]
+    except Exception as error:
+        raise HTTPException(status_code=400, detail=str(error))

--- a/app/models/booking.py
+++ b/app/models/booking.py
@@ -1,0 +1,7 @@
+from app.db.crud import MongoCrud
+from app.schema import bookings as booking_schema
+
+
+class BookingModel(MongoCrud[booking_schema.BookingDocument]):
+    def __init__(self):
+        super().__init__(booking_schema.BookingDocument)

--- a/app/services/booking.py
+++ b/app/services/booking.py
@@ -1,0 +1,57 @@
+from datetime import datetime, timedelta
+from typing import List, Optional
+
+from beanie.odm.operators.find.comparison import Eq, GTE, LTE
+from beanie.odm.operators.find.logical import And
+
+from app.models.booking import BookingModel
+from app.schema import bookings as booking_schema
+from app.schema.bookings import BookingDocument
+
+booking_model = BookingModel()
+
+
+async def create_booking(data: dict) -> booking_schema.BookingDocument:
+    return await booking_model.create(data)
+
+
+async def get_booking(booking_id: str) -> Optional[booking_schema.BookingDocument]:
+    return await booking_model.get(booking_id)
+
+
+async def update_booking(booking_id: str, data: booking_schema.BookingUpdate) -> Optional[booking_schema.BookingDocument]:
+    return await booking_model.update(booking_id, data.model_dump(exclude_none=True, by_alias=True))
+
+
+async def delete_booking(booking_id: str) -> bool:
+    return await booking_model.delete(booking_id)
+
+
+async def list_bookings_for_restaurant(restaurant_id: str) -> List[booking_schema.BookingDocument]:
+    return await booking_model.get_by_fields({"restaurantId": restaurant_id})
+
+
+async def list_bookings_for_table(table_id: str) -> List[booking_schema.BookingDocument]:
+    return await booking_model.get_by_fields({"tableId": table_id})
+
+
+async def list_upcoming_bookings(restaurant_id: str) -> List[booking_schema.BookingDocument]:
+    day = datetime.now().replace(minute=0, second=0, microsecond=0) - timedelta(hours=1)
+    return await BookingDocument.find(
+        And(
+            Eq(BookingDocument.restaurant_id, restaurant_id),
+            GTE(BookingDocument.start_time, day),
+        )
+    ).to_list()
+
+
+async def list_bookings_for_date(restaurant_id: str, date: datetime) -> List[booking_schema.BookingDocument]:
+    start = date.replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + timedelta(days=1)
+    return await BookingDocument.find(
+        And(
+            Eq(BookingDocument.restaurant_id, restaurant_id),
+            GTE(BookingDocument.start_time, start),
+            LTE(BookingDocument.start_time, end),
+        )
+    ).to_list()


### PR DESCRIPTION
## Summary
- implement `BookingModel` and CRUD services
- expose endpoints to manage bookings

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684a5f04a4cc8333bae90d63fba82401