### PR TITLE
Fix product IDs and supplier products type

### DIFF
--- a/app/schema/supplier.py
+++ b/app/schema/supplier.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import Optional
 
 from beanie import Document
 from bson import ObjectId
@@ -16,7 +16,7 @@ class SupplierCreate(BaseModel):
     email: str
     phone: str
     address: str
-    products: List[str] = Field(default_factory=list)
+    products: list[str] = Field(default_factory=list)
     rating: float
 
 


### PR DESCRIPTION
## Summary
- keep simple string Field for product IDs in movement and recipe schemas
- type supplier products list using builtin generics

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68503861cdfc8333a7d60d3e2ce6c1f5