### PR TITLE
Add stock management API

### DIFF
--- a/app/api/v1/endpoints/movements.py
+++ b/app/api/v1/endpoints/movements.py
@@ -1,0 +1,30 @@
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, HTTPException
+
+from app.schema import movement as movement_schema
+from app.services import movement as movement_service
+
+router = APIRouter()
+
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_movements(
+    restaurant_id: str,
+    product_id: Optional[str] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+):
+    movements = await movement_service.list_movements_for_restaurant(
+        restaurant_id, product_id=product_id, start=start, end=end
+    )
+    return [m.to_response() for m in movements]
+
+
+@router.post("/restaurant/{restaurant_id}")
+async def create_movement(restaurant_id: str, data: movement_schema.MovementCreate):
+    if data.restaurant_id != restaurant_id:
+        raise HTTPException(status_code=400, detail="Mismatched restaurant id")
+    movement = await movement_service.create_movement(data)
+    return movement.to_response()

--- a/app/api/v1/endpoints/recipes.py
+++ b/app/api/v1/endpoints/recipes.py
@@ -1,0 +1,36 @@
+from fastapi import APIRouter, HTTPException
+
+from app.schema import recipe as recipe_schema
+from app.services import recipe as recipe_service
+
+router = APIRouter()
+
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_recipes(restaurant_id: str):
+    recipes = await recipe_service.list_recipes_for_restaurant(restaurant_id)
+    return [r.to_response() for r in recipes]
+
+
+@router.post("/restaurant/{restaurant_id}")
+async def create_recipe(restaurant_id: str, data: recipe_schema.RecipeCreate):
+    if data.restaurant_id != restaurant_id:
+        raise HTTPException(status_code=400, detail="Mismatched restaurant id")
+    recipe = await recipe_service.create_recipe(data)
+    return recipe.to_response()
+
+
+@router.put("/{recipe_id}")
+async def update_recipe(recipe_id: str, data: recipe_schema.RecipeUpdate):
+    updated = await recipe_service.update_recipe(recipe_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    return updated.to_response()
+
+
+@router.delete("/{recipe_id}")
+async def delete_recipe(recipe_id: str):
+    deleted = await recipe_service.delete_recipe(recipe_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    return True

--- a/app/api/v1/endpoints/sales.py
+++ b/app/api/v1/endpoints/sales.py
@@ -1,0 +1,19 @@
+from fastapi import APIRouter, HTTPException, Body
+
+from app.services import sale as sale_service
+
+router = APIRouter()
+
+
+@router.get("/")
+async def list_sales():
+    sales = await sale_service.list_sales()
+    return [s.to_response() for s in sales]
+
+
+@router.post("/restaurant/{restaurant_id}")
+async def register_sale(restaurant_id: str, recipe_id: str = Body(..., alias="recipeId"), quantity: int = Body(...)):
+    sale = await sale_service.create_sale(recipe_id, quantity)
+    if not sale:
+        raise HTTPException(status_code=404, detail="Recipe not found")
+    return sale.to_response()

--- a/app/api/v1/endpoints/stock.py
+++ b/app/api/v1/endpoints/stock.py
@@ -1,0 +1,82 @@
+from fastapi import APIRouter, HTTPException, Body
+
+from app.schema import stock_item as stock_schema
+from app.services import stock_item as stock_service
+
+router = APIRouter()
+
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_stock_items(restaurant_id: str):
+    items = await stock_service.list_stock_items_for_restaurant(restaurant_id)
+    return [i.to_response() for i in items]
+
+
+@router.post("/restaurant/{restaurant_id}")
+async def create_stock_item(restaurant_id: str, data: stock_schema.StockItemCreate):
+    if data.restaurant_id != restaurant_id:
+        raise HTTPException(status_code=400, detail="Mismatched restaurant id")
+    item = await stock_service.create_stock_item(data)
+    return item.to_response()
+
+
+@router.get("/{item_id}")
+async def get_stock_item(item_id: str):
+    item = await stock_service.get_stock_item(item_id)
+    if not item:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return item.to_response()
+
+
+@router.put("/{item_id}")
+async def update_stock_item(item_id: str, data: stock_schema.StockItemUpdate):
+    updated = await stock_service.update_stock_item(item_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return updated.to_response()
+
+
+@router.delete("/{item_id}")
+async def delete_stock_item(item_id: str):
+    deleted = await stock_service.delete_stock_item(item_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return True
+
+
+@router.post("/{item_id}/add")
+async def add_stock(item_id: str, quantity: float = Body(...), reason: str = Body("", embed=True)):
+    updated = await stock_service.add_stock(item_id, quantity, reason)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return updated.to_response()
+
+
+@router.post("/{item_id}/remove")
+async def remove_stock(item_id: str, quantity: float = Body(...), reason: str = Body("", embed=True)):
+    updated = await stock_service.remove_stock(item_id, quantity, reason)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Item not found")
+    return updated.to_response()
+
+
+@router.get("/categories")
+async def list_categories():
+    return await stock_service.list_categories()
+
+
+@router.delete("/categories/{name}")
+async def delete_category(name: str):
+    count = await stock_service.delete_category(name)
+    return {"deleted": count}
+
+
+@router.get("/stats")
+async def get_stats(restaurant_id: str):
+    return await stock_service.get_stats(restaurant_id)
+
+
+@router.get("/auto-reorder")
+async def list_auto_reorder_items(restaurant_id: str):
+    items = await stock_service.list_auto_reorder_items(restaurant_id)
+    return [i.to_response() for i in items]

--- a/app/api/v1/endpoints/suppliers.py
+++ b/app/api/v1/endpoints/suppliers.py
@@ -1,0 +1,34 @@
+from fastapi import APIRouter, HTTPException
+
+from app.schema import supplier as supplier_schema
+from app.services import supplier as supplier_service
+
+router = APIRouter()
+
+
+@router.get("/restaurant/{restaurant_id}")
+async def list_suppliers(restaurant_id: str):
+    suppliers = await supplier_service.list_suppliers_for_restaurant(restaurant_id)
+    return [s.to_response() for s in suppliers]
+
+
+@router.post("/")
+async def create_supplier(data: supplier_schema.SupplierCreate):
+    supplier = await supplier_service.create_supplier(data)
+    return supplier.to_response()
+
+
+@router.put("/{supplier_id}")
+async def update_supplier(supplier_id: str, data: supplier_schema.SupplierUpdate):
+    updated = await supplier_service.update_supplier(supplier_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Supplier not found")
+    return updated.to_response()
+
+
+@router.delete("/{supplier_id}")
+async def delete_supplier(supplier_id: str):
+    deleted = await supplier_service.delete_supplier(supplier_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Supplier not found")
+    return True

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -1,6 +1,11 @@
 from fastapi import APIRouter
 
 from app.api.v1.endpoints.auth import router as auth_router
+from app.api.v1.endpoints.stock import router as stock_router
+from app.api.v1.endpoints.movements import router as movements_router
+from app.api.v1.endpoints.recipes import router as recipes_router
+from app.api.v1.endpoints.sales import router as sales_router
+from app.api.v1.endpoints.suppliers import router as suppliers_router
 from app.api.v1.endpoints.analytics import router as analytics_router
 from app.api.v1.endpoints.user import router as user_router
 from app.api.v1.endpoints.restaurants import router as analysis_router
@@ -36,4 +41,9 @@ router.include_router(tables_router, prefix="/tables", tags=["Tables"])
 router.include_router(table_sessions_router, prefix="/sessions", tags=["Table Sessions"])
 router.include_router(roles_router, prefix="/roles", tags=["Roles"])
 router.include_router(memberships_router, prefix="/memberships", tags=["Memberships"])
+router.include_router(stock_router, prefix="/stock", tags=["Stock"])
+router.include_router(movements_router, prefix="/movements", tags=["Movements"])
+router.include_router(recipes_router, prefix="/recipes", tags=["Recipes"])
+router.include_router(sales_router, prefix="/sales", tags=["Sales"])
+router.include_router(suppliers_router, prefix="/suppliers", tags=["Suppliers"])
 router.include_router(orders_router, prefix="/orders", tags=["Orders"])

--- a/app/services/movement.py
+++ b/app/services/movement.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import List, Optional
+
+from beanie.operators import And, GTE, LTE
+
+from app.models.movement import MovementModel
+from app.schema import movement as movement_schema
+
+movement_model = MovementModel()
+
+
+async def create_movement(data: movement_schema.MovementCreate) -> movement_schema.MovementDocument:
+    payload = data.model_dump(by_alias=True)
+    return await movement_model.create(payload)
+
+
+async def list_movements_for_restaurant(
+    restaurant_id: str,
+    product_id: Optional[str] = None,
+    start: Optional[datetime] = None,
+    end: Optional[datetime] = None,
+) -> List[movement_schema.MovementDocument]:
+    filters = {"restaurantId": restaurant_id}
+    if product_id:
+        filters["productId"] = product_id
+    query = movement_schema.MovementDocument.find(filters)
+    if start or end:
+        date_filter = {}
+        if start:
+            date_filter["$gte"] = start
+        if end:
+            date_filter["$lte"] = end
+        query = query.find({"date": date_filter})
+    return await query.sort("-date").to_list()

--- a/app/services/recipe.py
+++ b/app/services/recipe.py
@@ -1,0 +1,27 @@
+from typing import List, Optional
+
+from app.models.recipe import RecipeModel
+from app.schema import recipe as recipe_schema
+
+recipe_model = RecipeModel()
+
+
+async def create_recipe(data: recipe_schema.RecipeCreate) -> recipe_schema.RecipeDocument:
+    payload = data.model_dump(by_alias=True)
+    return await recipe_model.create(payload)
+
+
+async def get_recipe(recipe_id: str) -> Optional[recipe_schema.RecipeDocument]:
+    return await recipe_model.get(recipe_id)
+
+
+async def list_recipes_for_restaurant(restaurant_id: str) -> List[recipe_schema.RecipeDocument]:
+    return await recipe_model.get_by_fields({"restaurantId": restaurant_id})
+
+
+async def update_recipe(recipe_id: str, data: recipe_schema.RecipeUpdate) -> Optional[recipe_schema.RecipeDocument]:
+    return await recipe_model.update(recipe_id, data.model_dump(exclude_none=True, by_alias=True))
+
+
+async def delete_recipe(recipe_id: str) -> bool:
+    return await recipe_model.delete(recipe_id)

--- a/app/services/sale.py
+++ b/app/services/sale.py
@@ -1,0 +1,40 @@
+from typing import List, Optional
+
+from app.models.sale import SaleModel
+from app.schema import sale as sale_schema
+from app.schema import recipe as recipe_schema
+from app.services import stock_item as stock_service
+from app.models.recipe import RecipeModel
+from app.utils.time import now_in_luanda
+
+sale_model = SaleModel()
+recipe_model = RecipeModel()
+
+
+async def create_sale(recipe_id: str, quantity: int) -> Optional[sale_schema.SaleDocument]:
+    recipe = await recipe_model.get(recipe_id)
+    if not recipe:
+        return None
+
+    total = recipe.cost * quantity
+    sale_data = sale_schema.SaleCreate(
+        dishName=recipe.dish_name,
+        quantity=quantity,
+        date=now_in_luanda().isoformat(),
+        restaurantId=recipe.restaurant_id,
+        total=total,
+    )
+    sale = await sale_model.create(sale_data.model_dump(by_alias=True))
+
+    for ingredient in recipe.ingredients:
+        await stock_service.remove_stock(
+            ingredient.product_id,
+            ingredient.quantity * quantity,
+            reason=f"Sale of {recipe.dish_name}",
+            user="system",
+        )
+    return sale
+
+
+async def list_sales() -> List[sale_schema.SaleDocument]:
+    return await sale_model.get_all()

--- a/app/services/stock_item.py
+++ b/app/services/stock_item.py
@@ -1,0 +1,108 @@
+from datetime import datetime
+from typing import List, Optional
+
+from app.models.stock_item import StockItemModel
+from app.models.movement import MovementModel
+from app.schema import stock_item as stock_schema
+from app.schema import movement as movement_schema
+from app.utils.time import now_in_luanda
+
+stock_item_model = StockItemModel()
+movement_model = MovementModel()
+
+
+async def create_stock_item(data: stock_schema.StockItemCreate) -> stock_schema.StockItemDocument:
+    payload = data.model_dump(by_alias=True)
+    return await stock_item_model.create(payload)
+
+
+async def get_stock_item(item_id: str) -> Optional[stock_schema.StockItemDocument]:
+    return await stock_item_model.get(item_id)
+
+
+async def list_stock_items_for_restaurant(restaurant_id: str) -> List[stock_schema.StockItemDocument]:
+    return await stock_item_model.get_by_fields({"restaurantId": restaurant_id})
+
+
+async def update_stock_item(item_id: str, data: stock_schema.StockItemUpdate) -> Optional[stock_schema.StockItemDocument]:
+    return await stock_item_model.update(item_id, data.model_dump(exclude_none=True, by_alias=True))
+
+
+async def delete_stock_item(item_id: str) -> bool:
+    deleted = await stock_item_model.delete(item_id)
+    if deleted:
+        await movement_model.model.get_motor_collection().delete_many({"productId": item_id})
+    return deleted
+
+
+async def _create_movement(item: stock_schema.StockItemDocument, quantity: float, movement_type: movement_schema.MovementType, reason: str, user: str) -> movement_schema.MovementDocument:
+    data = movement_schema.MovementCreate(
+        productId=str(item.id),
+        productName=item.name,
+        type=movement_type,
+        quantity=quantity,
+        restaurantId=item.restaurant_id,
+        unit=item.unit,
+        date=now_in_luanda(),
+        reason=reason,
+        user=user,
+        cost=item.cost,
+    )
+    return await movement_model.create(data.model_dump(by_alias=True))
+
+
+async def add_stock(item_id: str, quantity: float, reason: str = "", user: str = "system") -> Optional[stock_schema.StockItemDocument]:
+    item = await stock_item_model.get(item_id)
+    if not item:
+        return None
+    new_quantity = item.current_quantity + quantity
+    updated = await stock_item_model.update(item_id, {"currentQuantity": new_quantity, "lastEntry": now_in_luanda().isoformat()})
+    await _create_movement(updated, quantity, movement_schema.MovementType.ENTRADA, reason, user)
+    return updated
+
+
+async def remove_stock(item_id: str, quantity: float, reason: str = "", user: str = "system") -> Optional[stock_schema.StockItemDocument]:
+    item = await stock_item_model.get(item_id)
+    if not item:
+        return None
+    new_quantity = item.current_quantity - quantity
+    if new_quantity < 0:
+        new_quantity = 0
+    updated = await stock_item_model.update(item_id, {"currentQuantity": new_quantity})
+    await _create_movement(updated, quantity, movement_schema.MovementType.SAIDA, reason, user)
+    return updated
+
+
+async def list_categories() -> List[str]:
+    coll = stock_schema.StockItemDocument.get_motor_collection()
+    return await coll.distinct("category")
+
+
+async def delete_category(name: str) -> int:
+    coll = stock_schema.StockItemDocument.get_motor_collection()
+    result = await coll.delete_many({"category": name})
+    return result.deleted_count
+
+
+async def get_stats(restaurant_id: str) -> dict:
+    items = await stock_item_model.get_by_fields({"restaurantId": restaurant_id})
+    total_items = len(items)
+    low_stock = len([i for i in items if i.status == stock_schema.StockStatus.BAIXO])
+    critical_stock = len([i for i in items if i.status == stock_schema.StockStatus.CRITICO])
+    total_value = sum((i.current_quantity * (i.cost or 0.0)) for i in items)
+    return {
+        "totalItems": total_items,
+        "lowStock": low_stock,
+        "criticalStock": critical_stock,
+        "totalValue": total_value,
+    }
+
+
+async def list_auto_reorder_items(restaurant_id: str) -> List[stock_schema.StockItemDocument]:
+    filters = {
+        "restaurantId": restaurant_id,
+        "autoReorder": True,
+        "reorderPoint": {"$ne": None},
+        "currentQuantity": {"$lte": {"$ifNull": ["$reorderPoint", 0]}}
+    }
+    return await stock_item_model.get_by_fields(filters)

--- a/app/services/supplier.py
+++ b/app/services/supplier.py
@@ -1,0 +1,27 @@
+from typing import List, Optional
+
+from app.models.supplier import SupplierModel
+from app.schema import supplier as supplier_schema
+
+supplier_model = SupplierModel()
+
+
+async def create_supplier(data: supplier_schema.SupplierCreate) -> supplier_schema.SupplierDocument:
+    payload = data.model_dump(by_alias=True)
+    return await supplier_model.create(payload)
+
+
+async def get_supplier(supplier_id: str) -> Optional[supplier_schema.SupplierDocument]:
+    return await supplier_model.get(supplier_id)
+
+
+async def list_suppliers_for_restaurant(restaurant_id: str) -> List[supplier_schema.SupplierDocument]:
+    return await supplier_model.get_by_fields({"restaurantId": restaurant_id})
+
+
+async def update_supplier(supplier_id: str, data: supplier_schema.SupplierUpdate) -> Optional[supplier_schema.SupplierDocument]:
+    return await supplier_model.update(supplier_id, data.model_dump(exclude_none=True, by_alias=True))
+
+
+async def delete_supplier(supplier_id: str) -> bool:
+    return await supplier_model.delete(supplier_id)

--- a/docs/api/stock-api.md
+++ b/docs/api/stock-api.md
@@ -7,40 +7,35 @@ endpoints and the data shapes used.
 ## Stock Items
 
 ### List stock items
-- **GET /api/v1/stock/:restaurant_id** – Returns an array of `StockItem` for a restaurant.
+- **GET /api/v1/stock/restaurant/{restaurant_id}** – Returns an array of `StockItem` for a restaurant.
 
-### Create a new item
-- **POST /api/v1/stock/:restaurant_id** – Expects `StockItemCreate`. Returns created
+- **POST /api/v1/stock/restaurant/{restaurant_id}** – Expects `StockItemCreate`. Returns created
   `StockItem`.
 
 ### Retrieve single item
-- **GET /api/v1/stock/:id** – Returns the `StockItem` with given `id`.
+- **GET /api/v1/stock/{id}** – Returns the `StockItem` with given `id`.
 
-### Update an item
-- **PUT /api/v1/stock/:id** – Accepts partial `StockItem` with fields to update.
+- **PUT /api/v1/stock/{id}** – Accepts partial `StockItem` with fields to update.
   Returns the updated `StockItem`.
 
-### Delete an item
-- **DELETE /api/v1/stock/:id** – Deletes the stock item. Should also remove
+- **DELETE /api/v1/stock/{id}** – Deletes the stock item. Should also remove
   related `Movement` records if needed.
 
-### Replenish stock / manual additions
-- **POST /api/v1/stock/:id/add** – Body: `{ quantity: number, reason?: string }`.
+- **POST /api/v1/stock/{id}/add** – Body: `{ quantity: number, reason?: string }`.
   Creates a new `Movement` of type `entrada` and updates the item's
   `currentQuantity` and `lastEntry`.
 
-### Remove stock (e.g. waste adjustments)
-- **POST /api/v1/stock/:id/remove** – Body: `{ quantity: number, reason?: string }`.
+- **POST /api/v1/stock/{id}/remove** – Body: `{ quantity: number, reason?: string }`.
   Adds a `Movement` of type `saída` or `ajuste` and updates the quantity.
 
 ## Movements
 
-### List movements
-- **GET /api/v1/movements/:restaurant_id** – Returns array of `Movement` ordered by date
+-### List movements
+- **GET /api/v1/movements/restaurant/{restaurant_id}** – Returns array of `Movement` ordered by date
   descending for a specific restaurant. Supports filtering by product or date range.
 
-### Create movement
-- **POST /api/v1/movements/:restaurant_id** – Create a movement record (for situations where the
+-### Create movement
+- **POST /api/v1/movements/restaurant/{restaurant_id}** – Create a movement record (for situations where the
   movement does not originate from another endpoint).
 
 ## Recipes
@@ -65,14 +60,14 @@ endpoints and the data shapes used.
 - **GET /api/v1/sales** – Returns array of `Sale`.
 
 ### Register sale
-- **POST /api/v1/sales/:restaurant_id** – Body: `{ recipeId: number, quantity: number }`.
+- **POST /api/v1/sales/restaurant/{restaurant_id}** – Body: `{ recipeId: string, quantity: number }`.
   Decrements stock for each ingredient, adds a `Movement` record for each item
   and creates a `Sale` entry.
 
 ## Suppliers
 
 ### List suppliers
-- **GET /api/v1/suppliers/:restaurant_id** – Returns array of `Supplier`.
+- **GET /api/v1/suppliers/restaurant/{restaurant_id}** – Returns array of `Supplier`.
 
 ### Create supplier
 - **POST /api/v1/suppliers** – Body: `Supplier` without `id`.
@@ -89,22 +84,21 @@ endpoints and the data shapes used.
 Although categories are simple strings on the page, an endpoint may be useful
 for managing them:
 - **GET /api/v1/stock/categories** – List distinct category names.
-- **DELETE /api/v1/categories/:name** – Remove a category (all items with such category name).
+- **DELETE /api/v1/stock/categories/{name}** – Remove a category (all items with such category name).
 g
 ## Stats and Reports
 
 The page displays statistics such as total products, items with low stock,
 critical items and total inventory value. These can be computed client‑side from
 the `/api/v1/stock` response, but for efficiency the backend may expose:
-- **GET /api/v1/stock/stats** – Returns totals, e.g. `{ totalItems, lowStock,
+- **GET /api/v1/stock/stats?restaurant_id={id}** – Returns totals, e.g. `{ totalItems, lowStock,
   criticalStock, totalValue }`.
 
 ## Purchase Orders and Auto Reorder
 
 Comments in the page suggest generating purchase orders and automatic
 replenishment. For that the backend could provide:
-- **GET /api/v1/stock/auto-reorder** – Returns items where `autoReorder` is true and
+- **GET /api/v1/stock/auto-reorder?restaurant_id={id}** – Returns items where `autoReorder` is true and
   `currentQuantity <= reorderPoint` along with suggested quantities.
-- **POST /api/v1/stock/purchase-orders** – Create a purchase order for given items
-  and quantities.
+  Purchase order creation is not implemented yet.
 


### PR DESCRIPTION
## Summary
- implement services for stock items, movements, recipes, sales and suppliers
- add corresponding API endpoints
- hook new routers into API v1 router
- update stock-api documentation with actual paths

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68504269e8648333bf95708b5cb6ea22