### PR TITLE
Add restaurant slug items endpoint

### DIFF
--- a/app/api/v1/endpoints/restaurants.py
+++ b/app/api/v1/endpoints/restaurants.py
@@ -18,6 +18,7 @@ from app.services.restaurant import (
     restaurant_model,
     change_current_menu,
     get_current_menu,
+    list_current_menu_items_by_slug,
 )
 from app.schema import restaurant as restaurant_schema
 from app.services.roles import create_default_roles_for_restaurant
@@ -284,6 +285,18 @@ async def get_restaurant_by_slug(slug: str):
     if not restaurant:
         raise HTTPException(status_code=404, detail="Restaurant not found")
     return restaurant.to_response()
+
+
+@router.get("/slug/{slug}/menu/items")
+async def list_current_menu_items(slug: str):
+    """Return all items in the restaurant's current menu identified by slug."""
+    try:
+        items = await list_current_menu_items_by_slug(slug)
+        return [i.to_response() for i in items]
+    except HTTPException:
+        raise
+    except Exception as error:
+        raise HTTPException(status_code=400, detail=str(error))
 
 
 

--- a/app/services/restaurant.py
+++ b/app/services/restaurant.py
@@ -5,6 +5,7 @@ from app.models.menu import MenuModel
 from app.models.restaurant import RestaurantModel
 from app.schema import restaurant as restaurant_schema
 from app.utils.slug import generate_unique_slug
+from app.services import item as item_service
 
 
 restaurant_model = RestaurantModel()
@@ -66,5 +67,18 @@ async def change_current_menu(restaurant_id: str, menu_id: str) -> bool:
 
     await restaurant_model.update(restaurant_id, {"currentMenuId": menu_id})
     return True
+
+
+async def list_current_menu_items_by_slug(slug: str):
+    """Return all available items in the restaurant's current menu using the restaurant slug."""
+    restaurant = await restaurant_model.get_by_slug(slug)
+    if not restaurant:
+        raise HTTPException(status_code=404, detail="Restaurant not found")
+
+    if not restaurant.current_menu_id:
+        return []
+
+    items = await item_service.list_items_by_menu(restaurant.current_menu_id)
+    return items
 
 

--- a/docs/tests/restaurants_test_cases.md
+++ b/docs/tests/restaurants_test_cases.md
@@ -1,0 +1,16 @@
+# Restaurants Module - Test Cases and Requirements
+
+This document lists basic requirements and test cases for the restaurants module. FastAPI endpoints live in `app/api/v1/endpoints/restaurants.py` with supporting logic in `app/services/restaurant.py`.
+
+## Basic Requirements
+
+1. **Current Menu Retrieval**
+   - Retrieve the restaurant's current menu by restaurant ID.
+   - Changing the current menu must validate that the menu belongs to the restaurant.
+2. **Item Listing by Slug**
+   - Given a restaurant slug, return all items in its current menu.
+   - If the slug does not exist, the endpoint should return HTTP 404.
+   - If the restaurant has no current menu, an empty list should be returned.
+
+These scenarios can be automated with a testing framework such as `pytest` and FastAPI's test client.
+


### PR DESCRIPTION
## Summary
- add service helper to fetch items for a restaurant's current menu via slug
- expose `/slug/{slug}/menu/items` endpoint in restaurants API
- document restaurant test cases covering the new route

## Testing
- `python -m py_compile app/api/v1/endpoints/restaurants.py app/services/restaurant.py`

------
https://chatgpt.com/codex/tasks/task_e_685b38882f508333a4bc6f5601f97d22