### PR TITLE
Add subscription management endpoints

### DIFF
--- a/app/api/v1/endpoints/subscriptions.py
+++ b/app/api/v1/endpoints/subscriptions.py
@@ -1,0 +1,81 @@
+from fastapi import APIRouter, HTTPException, Depends
+
+from app.services import subscription as subscription_service
+from app.schema import subscription_plan as plan_schema
+from app.schema import user_subscription as subscription_schema
+from app.utils.auth import admin_required
+
+router = APIRouter()
+
+
+# Subscription Plan CRUD
+@router.post('/plans', dependencies=[Depends(admin_required)])
+async def create_plan(data: plan_schema.SubscriptionPlanCreate):
+    try:
+        plan = await subscription_service.create_plan(data)
+        return plan.to_response()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.put('/plans/{plan_id}', dependencies=[Depends(admin_required)])
+async def update_plan(plan_id: str, data: plan_schema.SubscriptionPlanUpdate):
+    updated = await subscription_service.update_plan(plan_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail='Plan not found')
+    return updated.to_response()
+
+
+@router.delete('/plans/{plan_id}', dependencies=[Depends(admin_required)])
+async def delete_plan(plan_id: str):
+    deleted = await subscription_service.delete_plan(plan_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail='Plan not found')
+    return True
+
+
+@router.get('/plans/{plan_id}')
+async def get_plan(plan_id: str):
+    plan = await subscription_service.get_plan(plan_id)
+    if not plan:
+        raise HTTPException(status_code=404, detail='Plan not found')
+    return plan.to_response()
+
+
+@router.get('/plans')
+async def list_available_plans():
+    plans = await subscription_service.list_plans(active_only=True)
+    return [p.to_response() for p in plans]
+
+
+@router.get('/plans/all', dependencies=[Depends(admin_required)])
+async def list_all_plans():
+    plans = await subscription_service.list_plans()
+    return [p.to_response() for p in plans]
+
+
+# User Subscription Endpoints
+@router.post('/subscribe')
+async def subscribe(data: subscription_schema.UserSubscriptionCreate):
+    try:
+        sub = await subscription_service.subscribe_user(data.user_id, data.plan_id)
+        return sub.to_response()
+    except Exception as e:
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.post('/unsubscribe/{subscription_id}')
+async def unsubscribe(subscription_id: str):
+    updated = await subscription_service.unsubscribe(subscription_id)
+    if not updated:
+        raise HTTPException(status_code=404, detail='Subscription not found')
+    return updated.to_response()
+
+
+@router.get('/users/{user_id}/current')
+async def get_current_plan(user_id: str):
+    sub = await subscription_service.get_user_current_subscription(user_id)
+    if not sub:
+        return None
+    plan = await subscription_service.get_plan(sub.plan_id)
+    return plan.to_response() if plan else None

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -21,6 +21,7 @@ from app.api.v1.endpoints.table_sessions import router as table_sessions_router
 from app.api.v1.endpoints.roles import router as roles_router
 from app.api.v1.endpoints.memberships import router as memberships_router
 from app.api.v1.endpoints.orders import router as orders_router
+from app.api.v1.endpoints.subscriptions import router as subscriptions_router
 
 
 router = APIRouter()
@@ -47,3 +48,4 @@ router.include_router(recipes_router, prefix="/recipes", tags=["Recipes"])
 router.include_router(sales_router, prefix="/sales", tags=["Sales"])
 router.include_router(suppliers_router, prefix="/suppliers", tags=["Suppliers"])
 router.include_router(orders_router, prefix="/orders", tags=["Orders"])
+router.include_router(subscriptions_router, prefix="/subscriptions", tags=["Subscriptions"])

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -22,6 +22,8 @@ from app.schema import (
     sale,
     recipe,
     movement,
+    subscription_plan,
+    user_subscription,
 
 
 )
@@ -92,5 +94,7 @@ def get_mongo():
             sale.SaleDocument,
             recipe.RecipeDocument,
             movement.MovementDocument,
+            subscription_plan.SubscriptionPlanDocument,
+            user_subscription.UserSubscriptionDocument,
         ]
     )

--- a/app/models/subscription_plan.py
+++ b/app/models/subscription_plan.py
@@ -1,0 +1,6 @@
+from app.db.crud import MongoCrud
+from app.schema import subscription_plan as plan_schema
+
+class SubscriptionPlanModel(MongoCrud[plan_schema.SubscriptionPlanDocument]):
+    def __init__(self) -> None:
+        super().__init__(plan_schema.SubscriptionPlanDocument)

--- a/app/models/user_subscription.py
+++ b/app/models/user_subscription.py
@@ -1,0 +1,6 @@
+from app.db.crud import MongoCrud
+from app.schema import user_subscription as subscription_schema
+
+class UserSubscriptionModel(MongoCrud[subscription_schema.UserSubscriptionDocument]):
+    def __init__(self) -> None:
+        super().__init__(subscription_schema.UserSubscriptionDocument)

--- a/app/services/subscription.py
+++ b/app/services/subscription.py
@@ -1,0 +1,61 @@
+from typing import List, Optional
+
+from app.models.subscription_plan import SubscriptionPlanModel
+from app.models.user_subscription import UserSubscriptionModel
+from app.schema import subscription_plan as plan_schema
+from app.schema import user_subscription as subscription_schema
+from app.utils.time import now_in_luanda
+
+plan_model = SubscriptionPlanModel()
+subscription_model = UserSubscriptionModel()
+
+
+# Subscription Plan CRUD
+async def create_plan(data: plan_schema.SubscriptionPlanCreate) -> plan_schema.SubscriptionPlanDocument:
+    return await plan_model.create(data.model_dump(by_alias=True))
+
+
+async def update_plan(plan_id: str, data: plan_schema.SubscriptionPlanUpdate) -> Optional[plan_schema.SubscriptionPlanDocument]:
+    return await plan_model.update(plan_id, data.model_dump(exclude_none=True, by_alias=True))
+
+
+async def delete_plan(plan_id: str) -> bool:
+    return await plan_model.delete(plan_id)
+
+
+async def get_plan(plan_id: str) -> Optional[plan_schema.SubscriptionPlanDocument]:
+    return await plan_model.get(plan_id)
+
+
+async def list_plans(active_only: bool = False) -> List[plan_schema.SubscriptionPlanDocument]:
+    filters = {}
+    if active_only:
+        filters["isActive"] = True
+    if filters:
+        return await plan_model.get_by_fields(filters)
+    return await plan_model.get_all()
+
+
+# User Subscription management
+async def subscribe_user(user_id: str, plan_id: str) -> subscription_schema.UserSubscriptionDocument:
+    payload = subscription_schema.UserSubscriptionCreate(userId=user_id, planId=plan_id)
+    return await subscription_model.create(payload.model_dump(by_alias=True))
+
+
+async def unsubscribe(subscription_id: str) -> Optional[subscription_schema.UserSubscriptionDocument]:
+    data = {
+        "status": subscription_schema.SubscriptionStatus.CANCELLED,
+        "endDate": now_in_luanda(),
+    }
+    return await subscription_model.update(subscription_id, data)
+
+
+async def get_user_current_subscription(user_id: str) -> Optional[subscription_schema.UserSubscriptionDocument]:
+    subs = await subscription_model.get_by_fields({
+        "userId": user_id,
+        "status": subscription_schema.SubscriptionStatus.ACTIVE,
+    })
+    if not subs:
+        return None
+    subs.sort(key=lambda s: s.start_date, reverse=True)
+    return subs[0]


### PR DESCRIPTION
## Summary
- add models for SubscriptionPlan and UserSubscription
- create subscription service with plan CRUD and subscription helpers
- expose subscriptions API router with plan management and user actions
- register new router and models

## Testing
- `python -m py_compile $(git ls-files '*.py')` *(fails: SyntaxError because repo uses Python 3.12 features)*

------
https://chatgpt.com/codex/tasks/task_e_685becabb52c8333be8969a05114d3e6