### PR TITLE
Add deactivate menu endpoint

### DIFF
--- a/app/api/v1/endpoints/menus.py
+++ b/app/api/v1/endpoints/menus.py
@@ -49,6 +49,15 @@ async def update_menu_status(menu_id: str, is_active: bool):
     except Exception as error:
         raise HTTPException(status_code=404, detail=str(error))
 
+
+@router.put("/{menu_id}/deactivate")
+async def deactivate_menu(menu_id: str):
+    """Deactivate a menu by id by setting ``isActive`` to ``False``."""
+    try:
+        return await menu_service.deactivate_menu(menu_id)
+    except Exception as error:
+        raise HTTPException(status_code=404, detail=str(error))
+
 @router.get("/{menu_id}")
 async def get_menu(menu_id: str):
     menu = await menu_service.get_menu(menu_id)


### PR DESCRIPTION
## Summary
- allow a restaurant menu to be deactivated via `/menus/{menu_id}/deactivate`

## Testing
- `python -m py_compile app/api/v1/endpoints/menus.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dcee7182083339c067971cd7c2df5