### PR TITLE
Add activate menu endpoint

### DIFF
--- a/app/api/v1/endpoints/menus.py
+++ b/app/api/v1/endpoints/menus.py
@@ -58,6 +58,15 @@ async def deactivate_menu(menu_id: str):
     except Exception as error:
         raise HTTPException(status_code=404, detail=str(error))
 
+
+@router.put("/{menu_id}/activate")
+async def activate_menu(menu_id: str):
+    """Activate a menu by id by setting ``isActive`` to ``True``."""
+    try:
+        return await menu_service.activate_menu(menu_id)
+    except Exception as error:
+        raise HTTPException(status_code=404, detail=str(error))
+
 @router.get("/{menu_id}")
 async def get_menu(menu_id: str):
     menu = await menu_service.get_menu(menu_id)

--- a/app/services/menu.py
+++ b/app/services/menu.py
@@ -70,6 +70,12 @@ async def deactivate_menu(menu_id: str):
         raise Exception("Menu not found")
     return await menu_model.update(menu_id, {"isActive": False})
 
+async def activate_menu(menu_id: str):
+    menu = await menu_model.get(menu_id)
+    if not menu:
+        raise Exception("Menu not found")
+    return await menu_model.update(menu_id, {"isActive": True})
+
 async def update_menu_status(menu_id: str, is_active: bool):
     menu = await menu_model.get(menu_id)
     if not menu:

--- a/docs/tests/menus_test_cases.md
+++ b/docs/tests/menus_test_cases.md
@@ -1,0 +1,7 @@
+# Menus Module - Test Cases
+
+This file lists scenarios for menu related endpoints located in `app/api/v1/endpoints/menus.py`.
+
+## Activation Endpoint `/api/v1/menus/{menu_id}/activate`
+- **TC1.1** Valid menu ID sets `isActive` to `true` and returns the updated menu.
+- **TC1.2** Unknown menu ID returns HTTP 404 "Menu not found".


### PR DESCRIPTION
## Summary
- add service function to activate a menu
- expose new `PUT /{menu_id}/activate` endpoint
- document menu activation test cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685dd029e31c8333b577926fc22d4162