### PR TITLE
Broadcast table session changes

### DIFF
--- a/app/models/table_session.py
+++ b/app/models/table_session.py
@@ -1,8 +1,19 @@
+from typing import Dict, Any, Optional
+import json
+
 from app.db.crud import MongoCrud
 from app.schema import table_session as table_session_schema
+from app.services.websocket_manager import get_websocket_manger
 
 
 class TableSessionModel(MongoCrud[table_session_schema.TableSessionDocument]):
-
     def __init__(self):
         super().__init__(table_session_schema.TableSessionDocument)
+
+    async def update(self, _id: str, data: Dict[str, Any]) -> Optional[table_session_schema.TableSessionDocument]:
+        updated = await super().update(_id, data)
+        if updated and ("orders" in data or "status" in data):
+            websocket_manager = get_websocket_manger()
+            session_data = json.dumps(updated.to_response().model_dump())
+            await websocket_manager.broadcast(session_data, f"{updated.restaurant_id}/table-status")
+        return updated


### PR DESCRIPTION
## Summary
- send websocket notifications when table session orders or status update

## Testing
- `python -m py_compile app/models/table_session.py`
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_685f2d236b208333bc2f378664e90315