### PR TITLE
Add table clean endpoint

### DIFF
--- a/app/api/v1/endpoints/tables.py
+++ b/app/api/v1/endpoints/tables.py
@@ -100,3 +100,11 @@ async def reset_single_table_endpoint(table_id: str):
     if not table:
         raise HTTPException(status_code=404, detail="Table not found")
     return table.to_response()
+
+
+@router.post("/{table_id}/clean")
+async def clean_table_endpoint(table_id: str):
+    table = await table_service.clean_table(table_id)
+    if not table:
+        raise HTTPException(status_code=404, detail="Table not found")
+    return table.to_response()

--- a/docs/tests/sessions_test_cases.md
+++ b/docs/tests/sessions_test_cases.md
@@ -56,9 +56,14 @@ This document outlines the basic requirements and comprehensive test cases for t
 - **TC7.1** Deleting an existing session returns `True`.
 - **TC7.2** Deleting a non‑existent session returns `False`.
 
-### 8. General Edge Cases
-- **TC8.1** Ensure all endpoints require authentication where applicable.
-- **TC8.2** Stress test by rapidly opening and closing sessions to verify that invoices and new sessions are created correctly each time.
-- **TC8.3** Validate websocket broadcasts for order additions and session closures reach all connected clients.
+### 8. Clean Table `/api/v1/tables/{table_id}/clean`
+- **TC8.1** Cancels all orders for the active session and marks the session `cancelled`.
+- **TC8.2** A new empty session is created and linked to the table.
+- **TC8.3** Invalid table IDs return HTTP 404 without modifying data.
+
+### 9. General Edge Cases
+- **TC9.1** Ensure all endpoints require authentication where applicable.
+- **TC9.2** Stress test by rapidly opening and closing sessions to verify that invoices and new sessions are created correctly each time.
+- **TC9.3** Validate websocket broadcasts for order additions and session closures reach all connected clients.
 
 These test cases cover typical and edge scenarios for the table session workflow and can be implemented using a testing framework such as `pytest` along with FastAPI's test client to simulate requests.


### PR DESCRIPTION
## Summary
- implement `clean_table` service method to cancel orders and start a new session
- expose `POST /tables/{table_id}/clean` endpoint
- document basic test cases for the new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685f2fa36758833389d6e9df764000a3