### PR TITLE
Add endpoint to cancel session checkout

### DIFF
--- a/app/api/v1/endpoints/table_sessions.py
+++ b/app/api/v1/endpoints/table_sessions.py
@@ -15,17 +15,23 @@ async def paginate_sessions(
 ):
     try:
         filters: Dict[str, Any] = {}
-        result = await session_model.paginate(filters=filters, limit=limit, cursor=cursor)
+        result = await session_model.paginate(
+            filters=filters, limit=limit, cursor=cursor
+        )
         return result
     except Exception as error:
         print(error)
 
+
 @router.get("/active/{restaurant_id}/{table_number}")
 async def get_active_session_by_number(restaurant_id: str, table_number: str):
-    session = await session_service.get_active_session_for_restaurant_table(restaurant_id, int(table_number))
+    session = await session_service.get_active_session_for_restaurant_table(
+        restaurant_id, int(table_number)
+    )
     if not session:
         raise HTTPException(status_code=404, detail="Active session not found")
     return session.to_response()
+
 
 @router.get("/active/{table_id}")
 async def get_active_session(table_id: str):
@@ -33,6 +39,7 @@ async def get_active_session(table_id: str):
     if not session:
         raise HTTPException(status_code=404, detail="Active session not found")
     return session.to_response()
+
 
 @router.get("/table/{table_id}")
 async def list_sessions(table_id: str):
@@ -45,6 +52,7 @@ async def list_active_sessions(restaurant_id: str):
     sessions = await session_service.list_active_sessions_for_restaurant(restaurant_id)
     return [s.to_response() for s in sessions]
 
+
 @router.post("/{session_id}/close")
 async def close_session(session_id: str):
     try:
@@ -53,6 +61,7 @@ async def close_session(session_id: str):
         return new_session.to_response()
     except Exception as error:
         raise HTTPException(status_code=400, detail=str(error))
+
 
 @router.post("/{session_id}/cancel")
 async def cancel_session(session_id: str):
@@ -80,7 +89,16 @@ async def mark_session_needs_bill_endpoint(session_id: str):
         return session.to_response()
     except Exception as error:
         print(str(error))
-        raise HTTPException(
-            status_code=500,
-            detail=str(error)
-        )
+        raise HTTPException(status_code=500, detail=str(error))
+
+
+@router.post("/{session_id}/cancel-checkout")
+async def cancel_session_checkout_endpoint(session_id: str):
+    try:
+        session = await session_service.cancel_session_checkout(session_id)
+        if not session:
+            raise HTTPException(status_code=404, detail="Session not found")
+        return session.to_response()
+    except Exception as error:
+        print(str(error))
+        raise HTTPException(status_code=500, detail=str(error))

--- a/docs/tests/sessions_test_cases.md
+++ b/docs/tests/sessions_test_cases.md
@@ -59,24 +59,28 @@ This document outlines the basic requirements and comprehensive test cases for t
 ### 8. Mark Session Needs Bill `/api/v1/sessions/{session_id}/needs-bill`
 - **TC8.1** Updates the session status to `needs bill`.
 - **TC8.2** Unknown session IDs return HTTP 404.
+### 9. Cancel Checkout `/api/v1/sessions/{session_id}/cancel-checkout`
+- **TC9.1** Reverts the session status back to `active` when currently `needs bill`.
+- **TC9.2** Unknown session IDs return HTTP 404.
 
-### 9. Add Order to Session (Service)
-- **TC9.1** Adding a new order ID appends it to the session and broadcasts the update.
-- **TC9.2** Adding an order that already exists leaves the list unchanged.
-- **TC9.3** Providing an unknown session ID returns `None`.
 
-### 10. Delete Session (Service)
-- **TC10.1** Deleting an existing session returns `True`.
-- **TC10.2** Deleting a non‑existent session returns `False`.
+### 10. Add Order to Session (Service)
+- **TC10.1** Adding a new order ID appends it to the session and broadcasts the update.
+- **TC10.2** Adding an order that already exists leaves the list unchanged.
+- **TC10.3** Providing an unknown session ID returns `None`.
 
-### 11. Clean Table `/api/v1/tables/{table_id}/clean`
-- **TC11.1** Cancels all orders for the active session and marks the session `cancelled`.
-- **TC11.2** A new empty session is created and linked to the table.
-- **TC11.3** Invalid table IDs return HTTP 404 without modifying data.
+### 11. Delete Session (Service)
+- **TC11.1** Deleting an existing session returns `True`.
+- **TC11.2** Deleting a non‑existent session returns `False`.
 
-### 12. General Edge Cases
-- **TC12.1** Ensure all endpoints require authentication where applicable.
-- **TC12.2** Stress test by rapidly opening and closing sessions to verify that invoices and new sessions are created correctly each time.
-- **TC12.3** Validate websocket broadcasts for order additions and session closures reach all connected clients.
+### 12. Clean Table `/api/v1/tables/{table_id}/clean`
+- **TC12.1** Cancels all orders for the active session and marks the session `cancelled`.
+- **TC12.2** A new empty session is created and linked to the table.
+- **TC12.3** Invalid table IDs return HTTP 404 without modifying data.
+
+### 13. General Edge Cases
+- **TC13.1** Ensure all endpoints require authentication where applicable.
+- **TC13.2** Stress test by rapidly opening and closing sessions to verify that invoices and new sessions are created correctly each time.
+- **TC13.3** Validate websocket broadcasts for order additions and session closures reach all connected clients.
 
 These test cases cover typical and edge scenarios for the table session workflow and can be implemented using a testing framework such as `pytest` along with FastAPI's test client to simulate requests.


### PR DESCRIPTION
## Summary
- update table session service with `cancel_session_checkout`
- expose POST `/sessions/{session_id}/cancel-checkout`
- document new test cases for cancel checkout

## Testing
- `black app/services/table_session.py app/api/v1/endpoints/table_sessions.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6860b96cb1c48333a134d0d1d01c4a70