### PR TITLE
Add user preferences update endpoint

### DIFF
--- a/app/services/user.py
+++ b/app/services/user.py
@@ -10,3 +10,19 @@ async def create_user(user_data: dict, firebase_uid: str):
     user_data = user_schema.UserBase(**user_data, firebaseUUID=firebase_uid)
     user_dict = user_data.model_dump(by_alias=True)
     return await user_model.create(user_dict)
+
+
+async def update_user(user_id: str, data: user_schema.UserUpdate):
+    """Update a user by id applying only provided fields."""
+    update_data = data.model_dump(
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
+    return await user_model.update(user_id, update_data)
+
+
+async def update_user_preferences(user_id: str, preferences: user_schema.UserPreferences):
+    """Update only the preferences section of a user."""
+    pref_dict = preferences.model_dump(by_alias=True)
+    return await user_model.update(user_id, {"preferences": pref_dict})

--- a/docs/tests/user_preferences_test_cases.md
+++ b/docs/tests/user_preferences_test_cases.md
@@ -1,0 +1,4 @@
+# User Preferences Endpoint `/api/v1/users/preferences`
+
+- **TC1** Providing valid preferences updates the current user and returns the updated user document.
+- **TC2** If the authenticated user no longer exists, the endpoint returns HTTP 404 `User not found`.


### PR DESCRIPTION
## Summary
- expose service helpers for updating users and their preferences
- add `/api/v1/users/preferences` endpoint
- document basic test cases for updating user preferences

## Testing
- `python -m py_compile app/services/user.py app/api/v1/endpoints/user.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861aeba3e20833388970a14fba23f17