### PR TITLE
Add endpoint for purging unused sessions

### DIFF
--- a/app/api/v1/endpoints/table_sessions.py
+++ b/app/api/v1/endpoints/table_sessions.py
@@ -1,8 +1,9 @@
 from typing import Dict, Optional, Any
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Depends
 from app.services import table_session as session_service
 from app.services.table_session import session_model
+from app.utils.auth import admin_required
 
 router = APIRouter()
 
@@ -122,3 +123,15 @@ async def cancel_session_checkout_endpoint(session_id: str):
     except Exception as error:
         print(str(error))
         raise HTTPException(status_code=500, detail=str(error))
+
+
+@router.delete(
+    "/restaurant/{restaurant_id}/cleanup",
+    dependencies=[Depends(admin_required)],
+)
+async def delete_unlinked_sessions_endpoint(restaurant_id: str):
+    """Remove sessions not linked to any table for a restaurant."""
+    count = await session_service.delete_unlinked_sessions_for_restaurant(
+        restaurant_id
+    )
+    return {"deleted": count}

--- a/docs/tests/sessions_test_cases.md
+++ b/docs/tests/sessions_test_cases.md
@@ -78,9 +78,14 @@ This document outlines the basic requirements and comprehensive test cases for t
 - **TC12.2** A new empty session is created and linked to the table.
 - **TC12.3** Invalid table IDs return HTTP 404 without modifying data.
 
-### 13. General Edge Cases
-- **TC13.1** Ensure all endpoints require authentication where applicable.
-- **TC13.2** Stress test by rapidly opening and closing sessions to verify that invoices and new sessions are created correctly each time.
-- **TC13.3** Validate websocket broadcasts for order additions and session closures reach all connected clients.
+### 13. Delete Unlinked Sessions `/api/v1/sessions/restaurant/{restaurant_id}/cleanup`
+- **TC13.1** Returns the number of sessions removed that were not linked to any table.
+- **TC13.2** When all sessions are linked, the endpoint returns `0`.
+- **TC13.3** Unknown restaurant IDs result in `0` deletions.
+
+### 14. General Edge Cases
+- **TC14.1** Ensure all endpoints require authentication where applicable.
+- **TC14.2** Stress test by rapidly opening and closing sessions to verify that invoices and new sessions are created correctly each time.
+- **TC14.3** Validate websocket broadcasts for order additions and session closures reach all connected clients.
 
 These test cases cover typical and edge scenarios for the table session workflow and can be implemented using a testing framework such as `pytest` along with FastAPI's test client to simulate requests.


### PR DESCRIPTION
## Summary
- allow admins to delete unlinked table sessions
- document test cases for cleaning sessions

## Testing
- `python -m py_compile app/services/table_session.py app/api/v1/endpoints/table_sessions.py`

------
https://chatgpt.com/codex/tasks/task_e_6861cddf1a848333a9141ed10867b2a9