### PR TITLE
Add notifications endpoints

### DIFF
--- a/app/api/v1/endpoints/notifications.py
+++ b/app/api/v1/endpoints/notifications.py
@@ -1,0 +1,112 @@
+from typing import Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+
+from app.models.user import UserModel
+from app.schema import notification as notification_schema
+from app.services import notification as notification_service
+from app.utils.auth import get_current_user
+
+router = APIRouter()
+user_model = UserModel()
+
+
+@router.post("/")
+async def create_notification(data: notification_schema.NotificationCreate):
+    notification = await notification_service.create_notification(data)
+    return notification.to_response()
+
+
+@router.get("/")
+async def list_notifications(
+    n_type: Optional[notification_schema.NotificationType] = Query(None, alias="type"),
+    is_read: Optional[bool] = Query(None, alias="is_read"),
+    search: Optional[str] = Query(None),
+    page: int = Query(1, ge=1),
+    firebase_uid: str = Depends(get_current_user),
+):
+    user = await user_model.get_user_by_firebase_uid(firebase_uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    notifications = await notification_service.list_notifications(
+        str(user.id), n_type=n_type, is_read=is_read, search=search, page=page
+    )
+    return [n.to_response() for n in notifications]
+
+
+@router.get("/unread-count")
+async def unread_count(firebase_uid: str = Depends(get_current_user)):
+    user = await user_model.get_user_by_firebase_uid(firebase_uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    count = await notification_service.count_unread_notifications(str(user.id))
+    return {"unread": count}
+
+
+@router.get("/{notification_id}")
+async def get_notification(notification_id: str, firebase_uid: str = Depends(get_current_user)):
+    user = await user_model.get_user_by_firebase_uid(firebase_uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    notification = await notification_service.get_notification(notification_id)
+    if not notification or notification.user_id != str(user.id):
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    return notification.to_response()
+
+
+@router.post("/{notification_id}/read")
+async def mark_notification_read(notification_id: str, firebase_uid: str = Depends(get_current_user)):
+    user = await user_model.get_user_by_firebase_uid(firebase_uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    notification = await notification_service.get_notification(notification_id)
+    if not notification or notification.user_id != str(user.id):
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    updated = await notification_service.mark_notification_read(notification_id)
+    return updated.to_response() if updated else None
+
+
+@router.post("/{notification_id}/unread")
+async def mark_notification_unread(notification_id: str, firebase_uid: str = Depends(get_current_user)):
+    user = await user_model.get_user_by_firebase_uid(firebase_uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    notification = await notification_service.get_notification(notification_id)
+    if not notification or notification.user_id != str(user.id):
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    updated = await notification_service.mark_notification_unread(notification_id)
+    return updated.to_response() if updated else None
+
+
+@router.post("/read-all")
+async def mark_all_read(firebase_uid: str = Depends(get_current_user)):
+    user = await user_model.get_user_by_firebase_uid(firebase_uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    count = await notification_service.mark_all_notifications_read(str(user.id))
+    return {"updated": count}
+
+
+@router.delete("/{notification_id}")
+async def delete_notification(notification_id: str, firebase_uid: str = Depends(get_current_user)):
+    user = await user_model.get_user_by_firebase_uid(firebase_uid)
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    notification = await notification_service.get_notification(notification_id)
+    if not notification or notification.user_id != str(user.id):
+        raise HTTPException(status_code=404, detail="Notification not found")
+
+    deleted = await notification_service.delete_notification(notification_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Notification not found")
+    return True

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -22,6 +22,7 @@ from app.api.v1.endpoints.roles import router as roles_router
 from app.api.v1.endpoints.memberships import router as memberships_router
 from app.api.v1.endpoints.orders import router as orders_router
 from app.api.v1.endpoints.subscriptions import router as subscriptions_router
+from app.api.v1.endpoints.notifications import router as notifications_router
 
 
 router = APIRouter()
@@ -49,3 +50,4 @@ router.include_router(sales_router, prefix="/sales", tags=["Sales"])
 router.include_router(suppliers_router, prefix="/suppliers", tags=["Suppliers"])
 router.include_router(orders_router, prefix="/orders", tags=["Orders"])
 router.include_router(subscriptions_router, prefix="/subscriptions", tags=["Subscriptions"])
+router.include_router(notifications_router, prefix="/notifications", tags=["Notifications"])

--- a/app/models/notification.py
+++ b/app/models/notification.py
@@ -1,0 +1,7 @@
+from app.db.crud import MongoCrud
+from app.schema import notification as notification_schema
+
+
+class NotificationModel(MongoCrud[notification_schema.NotificationDocument]):
+    def __init__(self):
+        super().__init__(notification_schema.NotificationDocument)

--- a/app/services/notification.py
+++ b/app/services/notification.py
@@ -1,0 +1,74 @@
+from typing import Optional, List, Dict, Any
+
+from app.utils.time import now_in_luanda
+
+from app.models.notification import NotificationModel
+from app.schema import notification as notification_schema
+
+notification_model = NotificationModel()
+
+
+async def get_notification(notification_id: str) -> Optional[notification_schema.NotificationDocument]:
+    return await notification_model.get(notification_id)
+
+
+async def list_notifications(
+    user_id: str,
+    n_type: Optional[notification_schema.NotificationType] = None,
+    is_read: Optional[bool] = None,
+    search: Optional[str] = None,
+    page: int = 1,
+    page_size: int = 10,
+) -> List[notification_schema.NotificationDocument]:
+    filters: Dict[str, Any] = {"userId": user_id}
+    if n_type:
+        filters["notificationType"] = n_type
+    if is_read is not None:
+        filters["isRead"] = is_read
+    if search:
+        regex = {"$regex": search, "$options": "i"}
+        filters["$or"] = [{"title": regex}, {"message": regex}]
+
+    skip = max(page - 1, 0) * page_size
+    return await notification_model.get_by_fields(filters, skip=skip, limit=page_size)
+
+
+async def count_unread_notifications(user_id: str) -> int:
+    filters = {"userId": user_id, "isRead": False}
+    return await notification_schema.NotificationDocument.find(filters).count()
+
+
+async def create_notification(
+    data: notification_schema.NotificationCreate,
+) -> notification_schema.NotificationDocument:
+    payload = data.model_dump(by_alias=False)
+    payload["is_read"] = False
+    payload["read_on"] = None
+    return await notification_model.create(payload)
+
+
+async def mark_notification_read(
+    notification_id: str,
+) -> Optional[notification_schema.NotificationDocument]:
+    update = {"isRead": True, "readOn": now_in_luanda()}
+    return await notification_model.update(notification_id, update)
+
+
+async def mark_notification_unread(
+    notification_id: str,
+) -> Optional[notification_schema.NotificationDocument]:
+    update = {"isRead": False, "readOn": None}
+    return await notification_model.update(notification_id, update)
+
+
+async def mark_all_notifications_read(user_id: str) -> int:
+    coll = notification_schema.NotificationDocument.get_motor_collection()
+    result = await coll.update_many(
+        {"userId": user_id, "isRead": False},
+        {"$set": {"isRead": True, "readOn": now_in_luanda()}},
+    )
+    return result.modified_count
+
+
+async def delete_notification(notification_id: str) -> bool:
+    return await notification_model.delete(notification_id)

--- a/docs/tests/notifications_test_cases.md
+++ b/docs/tests/notifications_test_cases.md
@@ -1,0 +1,57 @@
+# Notifications Module - Test Cases and Requirements
+
+This document records test cases for the notifications module implemented in
+`app/api/v1/endpoints/notifications.py` using helper functions in
+`app/services/notification.py`.
+
+## Basic Requirements
+
+1. **Listing**
+   - Retrieve notifications for the authenticated user.
+   - Support filtering by type, read status and free text search on title or message.
+   - Pagination is done using the `page` query parameter with a default page size of 10.
+2. **Unread Count**
+   - Provide an endpoint to return the total number of unread notifications for the user.
+3. **Retrieval**
+   - Fetch a single notification by its ID and ensure it belongs to the current user.
+4. **Creation**
+   - Allow creation of a notification document for a user.
+5. **Status Updates**
+   - Provide endpoints to mark a notification read or unread and mark all as read.
+6. **Deletion**
+   - Delete a notification by ID with proper ownership checks.
+
+## Test Cases
+
+### 1. List Notifications `/api/v1/notifications`
+- **TC1.1** No filters returns the first page of notifications for the user.
+- **TC1.2** `type` and `is_read` filter the results accordingly.
+- **TC1.3** `search` performs a case-insensitive match on title and message.
+- **TC1.4** Invalid authentication returns HTTP 401.
+
+### 2. Unread Count `/api/v1/notifications/unread-count`
+- **TC2.1** Returns the correct number of unread notifications.
+- **TC2.2** If none are unread, returns `0`.
+
+### 3. Get Notification `/api/v1/notifications/{id}`
+- **TC3.1** Valid ID belonging to the user returns the notification document.
+- **TC3.2** Non-existent or foreign IDs return HTTP 404.
+
+### 4. Create Notification `/api/v1/notifications`
+- **TC4.1** Valid payload creates a notification for the specified user.
+- **TC4.2** Missing required fields returns HTTP 400 validation error.
+
+### 5. Mark Read `/api/v1/notifications/{id}/read`
+- **TC5.1** Marks the notification as read and sets `readOn` timestamp.
+- **TC5.2** Foreign IDs return HTTP 404.
+
+### 6. Mark Unread `/api/v1/notifications/{id}/unread`
+- **TC6.1** Marks the notification as unread and clears `readOn`.
+- **TC6.2** Foreign IDs return HTTP 404.
+
+### 7. Mark All Read `/api/v1/notifications/read-all`
+- **TC7.1** Updates all unread notifications for the user and returns the count.
+
+### 8. Delete Notification `/api/v1/notifications/{id}`
+- **TC8.1** Valid ID deletes the notification and returns `True`.
+- **TC8.2** Foreign IDs return HTTP 404.


### PR DESCRIPTION
## Summary
- add `NotificationModel` and corresponding service helpers
- expose notifications API routes and wire into router
- document notifications module test cases
- extend notifications API

## Testing
- `python -m py_compile app/api/v1/endpoints/notifications.py app/services/notification.py`


------
https://chatgpt.com/codex/tasks/task_e_6861fe2a516883339bfba2651db007c7