### PR TITLE
Add opening hours update endpoint

### DIFF
--- a/app/api/v1/endpoints/restaurants.py
+++ b/app/api/v1/endpoints/restaurants.py
@@ -21,6 +21,7 @@ from app.services.restaurant import (
     get_restaurant,
     get_by_slug,
     update_restaurant,
+    update_opening_hours,
     delete_restaurant,
     get_restaurants,
     get_active_restaurants,
@@ -331,6 +332,15 @@ async def update_existing_restaurant(
     restaurant_id: str, data: restaurant_schema.RestaurantUpdate
 ):
     return await update_restaurant(restaurant_id, data)
+
+
+@router.put("/{restaurant_id}/opening-hours")
+async def update_restaurant_opening_hours(
+    restaurant_id: str, opening_hours: restaurant_schema.OpeningHours
+):
+    """Update only the opening hours for a restaurant."""
+    updated = await update_opening_hours(restaurant_id, opening_hours)
+    return updated.to_response()
 
 
 @router.put("/{restaurant_id}/banner")

--- a/app/services/restaurant.py
+++ b/app/services/restaurant.py
@@ -82,3 +82,19 @@ async def list_current_menu_items_by_slug(slug: str):
     return items
 
 
+async def update_opening_hours(
+    restaurant_id: str, opening_hours: restaurant_schema.OpeningHours
+) -> restaurant_schema.RestaurantDocument:
+    """Update a restaurant's opening hours settings."""
+    restaurant = await restaurant_model.get(restaurant_id)
+    if not restaurant:
+        raise HTTPException(status_code=404, detail="Restaurant not found")
+
+    update_data = {
+        "settings.openingHours": opening_hours.model_dump(by_alias=True)
+    }
+
+    updated = await restaurant_model.update(restaurant_id, update_data)
+    return updated
+
+

--- a/docs/tests/restaurants_test_cases.md
+++ b/docs/tests/restaurants_test_cases.md
@@ -11,6 +11,11 @@ This document lists basic requirements and test cases for the restaurants module
    - Given a restaurant slug, return all items in its current menu.
    - If the slug does not exist, the endpoint should return HTTP 404.
    - If the restaurant has no current menu, an empty list should be returned.
+3. **Opening Hours Update**
+   - Restaurants should be able to update their opening hours through a
+     dedicated endpoint.
+   - The endpoint accepts the ``OpeningHours`` schema and returns the updated
+     restaurant document.
 
 These scenarios can be automated with a testing framework such as `pytest` and FastAPI's test client.
 


### PR DESCRIPTION
## Summary
- allow updating only the opening hours for a restaurant
- document opening hours update in the restaurant test cases

## Testing
- `python -m py_compile app/services/restaurant.py app/api/v1/endpoints/restaurants.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6863cfcf85a48333ac213c3f0649a457