### PR TITLE
Add diagnostics route for data integrity checks

### DIFF
--- a/app/api/v1/endpoints/diagnostics.py
+++ b/app/api/v1/endpoints/diagnostics.py
@@ -1,0 +1,29 @@
+from fastapi import APIRouter
+
+from app.services import diagnostics as diag_service
+
+router = APIRouter()
+
+
+@router.get("/sessions/duplicates")
+async def get_duplicate_sessions():
+    """List tables with more than one active session."""
+    return await diag_service.duplicate_active_sessions()
+
+
+@router.get("/sessions/current-mismatch")
+async def get_current_session_mismatches():
+    """Find tables whose currentSessionId does not match an active session."""
+    return await diag_service.mismatched_current_sessions()
+
+
+@router.get("/sessions/orphans")
+async def get_orphan_sessions():
+    """Return sessions not linked to any table."""
+    return await diag_service.orphan_sessions()
+
+
+@router.get("/run-all")
+async def run_all_diagnostics():
+    """Execute all diagnostic checks and return their results."""
+    return await diag_service.run_all()

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -23,6 +23,7 @@ from app.api.v1.endpoints.memberships import router as memberships_router
 from app.api.v1.endpoints.orders import router as orders_router
 from app.api.v1.endpoints.subscriptions import router as subscriptions_router
 from app.api.v1.endpoints.notifications import router as notifications_router
+from app.api.v1.endpoints.diagnostics import router as diagnostics_router
 
 
 router = APIRouter()
@@ -40,7 +41,9 @@ router.include_router(items_router, prefix="/items", tags=["Items"])
 router.include_router(menus_router, prefix="/menus", tags=["Menus"])
 router.include_router(categories_router, prefix="/categories", tags=["Categories"])
 router.include_router(tables_router, prefix="/tables", tags=["Tables"])
-router.include_router(table_sessions_router, prefix="/sessions", tags=["Table Sessions"])
+router.include_router(
+    table_sessions_router, prefix="/sessions", tags=["Table Sessions"]
+)
 router.include_router(roles_router, prefix="/roles", tags=["Roles"])
 router.include_router(memberships_router, prefix="/memberships", tags=["Memberships"])
 router.include_router(stock_router, prefix="/stock", tags=["Stock"])
@@ -49,5 +52,10 @@ router.include_router(recipes_router, prefix="/recipes", tags=["Recipes"])
 router.include_router(sales_router, prefix="/sales", tags=["Sales"])
 router.include_router(suppliers_router, prefix="/suppliers", tags=["Suppliers"])
 router.include_router(orders_router, prefix="/orders", tags=["Orders"])
-router.include_router(subscriptions_router, prefix="/subscriptions", tags=["Subscriptions"])
-router.include_router(notifications_router, prefix="/notifications", tags=["Notifications"])
+router.include_router(
+    subscriptions_router, prefix="/subscriptions", tags=["Subscriptions"]
+)
+router.include_router(
+    notifications_router, prefix="/notifications", tags=["Notifications"]
+)
+router.include_router(diagnostics_router, prefix="/diagnostics", tags=["Diagnostics"])

--- a/app/services/diagnostics.py
+++ b/app/services/diagnostics.py
@@ -1,0 +1,102 @@
+from typing import Any, Dict, List
+
+from bson import ObjectId
+
+from app.models.table import TableModel
+from app.models.table_session import TableSessionModel
+from app.schema.table_session import TableSessionStatus, TableSessionDocument
+
+
+table_model = TableModel()
+session_model = TableSessionModel()
+
+
+async def duplicate_active_sessions() -> List[Dict[str, Any]]:
+    """Return tables that have more than one active session."""
+    coll = TableSessionDocument.get_motor_collection()
+    pipeline = [
+        {
+            "$match": {
+                "status": {
+                    "$in": [
+                        TableSessionStatus.ACTIVE.value,
+                        TableSessionStatus.NEED_BILL.value,
+                    ]
+                }
+            }
+        },
+        {
+            "$group": {
+                "_id": "$tableId",
+                "count": {"$sum": 1},
+                "sessions": {"$push": "$_id"},
+            }
+        },
+        {"$match": {"count": {"$gt": 1}}},
+    ]
+    docs = await coll.aggregate(pipeline).to_list(None)
+    return [
+        {
+            "tableId": d["_id"],
+            "sessionIds": [str(s) for s in d["sessions"]],
+            "count": d["count"],
+        }
+        for d in docs
+    ]
+
+
+async def mismatched_current_sessions() -> List[Dict[str, Any]]:
+    """Return tables whose currentSessionId does not match an active session."""
+    tables = await table_model.get_all()
+    mismatches: List[Dict[str, Any]] = []
+    for t in tables:
+        sessions = await TableSessionDocument.find(
+            (
+                (TableSessionDocument.table_id == str(t.id))
+                & (
+                    TableSessionDocument.status.in_(
+                        [TableSessionStatus.ACTIVE, TableSessionStatus.NEED_BILL]
+                    )
+                )
+            )
+        ).to_list()
+        active_ids = [str(s.id) for s in sessions]
+        if t.current_session_id not in active_ids:
+            mismatches.append(
+                {
+                    "tableId": str(t.id),
+                    "restaurantId": t.restaurant_id,
+                    "tableNumber": t.number,
+                    "currentSessionId": t.current_session_id,
+                    "activeSessionIds": active_ids,
+                }
+            )
+    return mismatches
+
+
+async def orphan_sessions() -> List[Dict[str, Any]]:
+    """Return sessions that are not referenced by any table."""
+    tables = await table_model.get_all()
+    linked_ids = {t.current_session_id for t in tables if t.current_session_id}
+    coll = TableSessionDocument.get_motor_collection()
+    query: Dict[str, Any] = {}
+    if linked_ids:
+        object_ids = [ObjectId(sid) for sid in linked_ids]
+        query = {"_id": {"$nin": object_ids}}
+    docs = await coll.find(query).to_list(None)
+    return [
+        {
+            "sessionId": str(d["_id"]),
+            "tableId": d.get("tableId"),
+            "status": d.get("status"),
+        }
+        for d in docs
+    ]
+
+
+async def run_all() -> Dict[str, Any]:
+    return {
+        "duplicateActiveSessions": await duplicate_active_sessions(),
+        "currentSessionMismatches": await mismatched_current_sessions(),
+        "orphanSessions": await orphan_sessions(),
+    }


### PR DESCRIPTION
## Summary
- add diagnostics service with checks for table sessions
- create diagnostics API endpoints
- register diagnostics router in API

## Testing
- `black app/services/diagnostics.py app/api/v1/endpoints/diagnostics.py app/api/v1/router.py`

------
https://chatgpt.com/codex/tasks/task_e_6863d93df7cc8333a660599ba395a77d