### PR TITLE
Add automatic stock adjustment endpoint

### DIFF
--- a/app/api/v1/endpoints/restaurants.py
+++ b/app/api/v1/endpoints/restaurants.py
@@ -22,6 +22,7 @@ from app.services.restaurant import (
     get_by_slug,
     update_restaurant,
     update_opening_hours,
+    update_automatic_stock_adjustments,
     delete_restaurant,
     get_restaurants,
     get_active_restaurants,
@@ -340,6 +341,18 @@ async def update_restaurant_opening_hours(
 ):
     """Update only the opening hours for a restaurant."""
     updated = await update_opening_hours(restaurant_id, opening_hours)
+    return updated.to_response()
+
+
+@router.put("/{restaurant_id}/automatic-stock-adjustments")
+async def update_restaurant_automatic_stock(
+    restaurant_id: str,
+    automatic_stock_adjustments: bool = Body(..., alias="automaticStockAdjustments"),
+):
+    """Enable or disable automatic stock adjustments for a restaurant."""
+    updated = await update_automatic_stock_adjustments(
+        restaurant_id, automatic_stock_adjustments
+    )
     return updated.to_response()
 
 

--- a/app/services/restaurant.py
+++ b/app/services/restaurant.py
@@ -98,3 +98,17 @@ async def update_opening_hours(
     return updated
 
 
+async def update_automatic_stock_adjustments(
+    restaurant_id: str, enable: bool
+) -> restaurant_schema.RestaurantDocument:
+    """Toggle automatic stock adjustments for a restaurant."""
+    restaurant = await restaurant_model.get(restaurant_id)
+    if not restaurant:
+        raise HTTPException(status_code=404, detail="Restaurant not found")
+
+    update_data = {"settings.automaticStockAdjustments": enable}
+
+    updated = await restaurant_model.update(restaurant_id, update_data)
+    return updated
+
+

--- a/docs/tests/restaurants_test_cases.md
+++ b/docs/tests/restaurants_test_cases.md
@@ -16,6 +16,11 @@ This document lists basic requirements and test cases for the restaurants module
      dedicated endpoint.
    - The endpoint accepts the ``OpeningHours`` schema and returns the updated
      restaurant document.
+4. **Automatic Stock Adjustments**
+   - Restaurants can toggle automatic stock adjustments using a dedicated
+     endpoint.
+   - The endpoint accepts a boolean ``automaticStockAdjustments`` and returns
+     the updated restaurant document.
 
 These scenarios can be automated with a testing framework such as `pytest` and FastAPI's test client.
 


### PR DESCRIPTION
## Summary
- add service function to toggle automatic stock adjustments
- expose REST endpoint `/restaurants/{restaurant_id}/automatic-stock-adjustments`
- document new requirement in restaurant test cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686587e39fec83338b5ba7c0c2f27cf0