### PR TITLE
Add user context to stock movements

### DIFF
--- a/app/services/stock_item.py
+++ b/app/services/stock_item.py
@@ -9,9 +9,14 @@ from app.utils.time import now_in_luanda
 
 stock_item_model = StockItemModel()
 
-async def create_stock_item(data: stock_schema.StockItemCreate) -> stock_schema.StockItemDocument:
+async def create_stock_item(
+    data: stock_schema.StockItemCreate,
+    *,
+    user: str = "system",
+    reason: str = "",
+) -> stock_schema.StockItemDocument:
     payload = data.model_dump(by_alias=True)
-    new_stock_item = await stock_item_model.create(payload)
+    new_stock_item = await stock_item_model.create(payload, user=user, reason=reason)
     return new_stock_item
 
 
@@ -23,32 +28,68 @@ async def list_stock_items_for_restaurant(restaurant_id: str) -> List[stock_sche
     return await stock_item_model.get_by_fields({"restaurantId": restaurant_id})
 
 
-async def update_stock_item(item_id: str, data: stock_schema.StockItemUpdate) -> Optional[stock_schema.StockItemDocument]:
-    return await stock_item_model.update(item_id, data.model_dump(exclude_none=True, by_alias=True))
+async def update_stock_item(
+    item_id: str,
+    data: stock_schema.StockItemUpdate,
+    *,
+    user: str = "system",
+    reason: str = "",
+) -> Optional[stock_schema.StockItemDocument]:
+    return await stock_item_model.update(
+        item_id,
+        data.model_dump(exclude_none=True, by_alias=True),
+        user=user,
+        reason=reason,
+    )
 
 
-async def delete_stock_item(item_id: str) -> bool:
-    deleted = await stock_item_model.delete(item_id)
+async def delete_stock_item(
+    item_id: str,
+    *,
+    user: str = "system",
+    reason: str = "",
+) -> bool:
+    deleted = await stock_item_model.delete(item_id, user=user, reason=reason)
     return deleted
 
 
-async def add_stock(item_id: str, quantity: float, reason: str = "", user: str = "system") -> Optional[stock_schema.StockItemDocument]:
+async def add_stock(
+    item_id: str,
+    quantity: float,
+    reason: str = "",
+    user: str = "system",
+) -> Optional[stock_schema.StockItemDocument]:
     item = await stock_item_model.get(item_id)
     if not item:
         return None
     new_quantity = item.current_quantity + quantity
-    updated = await stock_item_model.update(item_id, {"currentQuantity": new_quantity, "lastEntry": now_in_luanda().isoformat()})
+    updated = await stock_item_model.update(
+        item_id,
+        {"currentQuantity": new_quantity, "lastEntry": now_in_luanda().isoformat()},
+        user=user,
+        reason=reason,
+    )
     return updated
 
 
-async def remove_stock(item_id: str, quantity: float, reason: str = "", user: str = "system") -> Optional[stock_schema.StockItemDocument]:
+async def remove_stock(
+    item_id: str,
+    quantity: float,
+    reason: str = "",
+    user: str = "system",
+) -> Optional[stock_schema.StockItemDocument]:
     item = await stock_item_model.get(item_id)
     if not item:
         return None
     new_quantity = item.current_quantity - quantity
     if new_quantity < 0:
         new_quantity = 0
-    updated = await stock_item_model.update(item_id, {"currentQuantity": new_quantity})
+    updated = await stock_item_model.update(
+        item_id,
+        {"currentQuantity": new_quantity},
+        user=user,
+        reason=reason,
+    )
     return updated
 
 


### PR DESCRIPTION
## Summary
- pass user name when creating or updating stock items so movement entries know who performed the action
- fetch current user info in stock endpoints and forward the name to the service layer

## Testing
- `python3.12 -m py_compile $(git ls-files '*.py')`
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686831d6f530833389d9235e34288458