### PR TITLE
Add order reference in Portuguese stock movements

### DIFF
--- a/app/services/order.py
+++ b/app/services/order.py
@@ -98,7 +98,7 @@ async def place_order(data: dict) -> order_schema.OrderDocument:
                         await stock_item_service.remove_stock(
                             str(stock_item.id),
                             ingredient.quantity * order.quantity,
-                            reason=f"Order {order.id}",
+                            reason=f"Venda de {order.id}",
                         )
 
                 if ingredients_updated:


### PR DESCRIPTION
## Summary
- include a localized stock movement reason when adjusting stock for orders

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68683679af148333a300e01b98edd520