### PR TITLE
Add menu category count endpoint

### DIFF
--- a/app/api/v1/endpoints/categories.py
+++ b/app/api/v1/endpoints/categories.py
@@ -114,6 +114,25 @@ async def list_menu_categories_by_slug(menu_slug: str):
             status_code=400
         )
 
+
+@router.get("/menu/slug/{menu_slug}/count")
+async def count_menu_categories(menu_slug: str):
+    """Return how many categories belong to the menu with the given slug."""
+    try:
+        menu = await menu_model.get_by_slug(menu_slug)
+        if not menu:
+            raise HTTPException(
+                detail="The menu was not found",
+                status_code=400,
+            )
+
+        count = await category_service.count_categories_for_menu(str(menu.id))
+        return count
+    except HTTPException:
+        raise
+    except Exception as error:
+        raise HTTPException(detail=str(error), status_code=400)
+
 @router.get("/restaurant/{restaurant_id}")
 async def list_restaurant_categories(restaurant_id: str):
     categories = await category_service.list_categories_for_restaurant(restaurant_id)

--- a/app/services/category.py
+++ b/app/services/category.py
@@ -62,3 +62,9 @@ async def remove_item_from_category(category_id: str, item_id: str):
 
 async def get_category_by_slug(slug: str):
     return await category_model.get_by_slug(slug)
+
+
+async def count_categories_for_menu(menu_id: str) -> int:
+    """Return the number of categories linked to a menu."""
+    filters = {"menuId": menu_id}
+    return await category_schema.CategoryDocument.find(filters).count()

--- a/docs/tests/categories_test_cases.md
+++ b/docs/tests/categories_test_cases.md
@@ -70,6 +70,10 @@ This document describes the basic requirements and a comprehensive list of test 
 - **TC11.1** Existing slug returns categories for the menu.
 - **TC11.2** Unknown slug returns HTTP 400 "The menu was not found".
 
+### 11b. Count Categories by Menu Slug `/api/v1/categories/menu/slug/{menu_slug}/count`
+- **TC11b.1** Existing slug returns the number of categories for the menu.
+- **TC11b.2** Unknown slug returns HTTP 400 "The menu was not found".
+
 ### 12. List Categories for Restaurant `/api/v1/categories/restaurant/{restaurant_id}`
 - **TC12.1** Valid ID returns categories for that restaurant.
 - **TC12.2** Restaurant with no categories returns an empty list.


### PR DESCRIPTION
## Summary
- add service helper to count menu categories
- expose `/categories/menu/slug/{menu_slug}/count` endpoint
- document test cases for new endpoint

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686839ab59088333977a59360cf939c1