### PR TITLE
Add paginated sales report endpoint

### DIFF
--- a/app/api/v1/endpoints/reports.py
+++ b/app/api/v1/endpoints/reports.py
@@ -1,0 +1,26 @@
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+from app.services.reports import paginate_sales_reports
+
+router = APIRouter()
+
+
+@router.get("/sales/paginate")
+async def sales_report_paginate(
+    restaurant_id: str = Query(..., alias="restaurantId"),
+    from_date: datetime = Query(..., alias="fromDate"),
+    to_date: datetime = Query(..., alias="toDate"),
+    limit: int = Query(10, gt=0),
+    cursor: Optional[str] = Query(None),
+):
+    """Paginate sales reports for a restaurant within a date range."""
+    return await paginate_sales_reports(
+        restaurant_id=restaurant_id,
+        from_date=from_date,
+        to_date=to_date,
+        limit=limit,
+        cursor=cursor,
+    )

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -25,6 +25,7 @@ from app.api.v1.endpoints.invoices import router as invoices_router
 from app.api.v1.endpoints.subscriptions import router as subscriptions_router
 from app.api.v1.endpoints.notifications import router as notifications_router
 from app.api.v1.endpoints.diagnostics import router as diagnostics_router
+from app.api.v1.endpoints.reports import router as reports_router
 
 
 router = APIRouter()
@@ -57,6 +58,7 @@ router.include_router(invoices_router, prefix="/invoices", tags=["Invoices"])
 router.include_router(
     subscriptions_router, prefix="/subscriptions", tags=["Subscriptions"]
 )
+router.include_router(reports_router, prefix="/reports", tags=["Reports"])
 router.include_router(
     notifications_router, prefix="/notifications", tags=["Notifications"]
 )

--- a/app/schema/reports.py
+++ b/app/schema/reports.py
@@ -11,3 +11,14 @@ class SalesReport(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True
     )
+
+
+class SalesReportPagination(BaseModel):
+    """Paginated list of ``SalesReport`` entries."""
+
+    items: list[SalesReport]
+    next_cursor: str | None = Field(default=None, alias="nextCursor")
+    total_count: int = Field(..., alias="totalCount")
+    has_more: bool = Field(..., alias="hasMore")
+
+    model_config = ConfigDict(populate_by_name=True)

--- a/app/services/reports.py
+++ b/app/services/reports.py
@@ -1,0 +1,62 @@
+from datetime import datetime
+from typing import List, Optional
+
+from app.schema.reports import SalesReport, SalesReportPagination
+from app.schema.invoice import InvoiceDocument, InvoiceStatus
+
+
+async def _aggregate_sales(
+    restaurant_id: str,
+    from_date: datetime,
+    to_date: datetime,
+) -> List[SalesReport]:
+    """Return aggregated sales for each day in the range."""
+    coll = InvoiceDocument.get_motor_collection()
+    pipeline = [
+        {
+            "$match": {
+                "restaurantId": restaurant_id,
+                "createdAt": {"$gte": from_date, "$lte": to_date},
+                "status": InvoiceStatus.PAID.value,
+            }
+        },
+        {
+            "$group": {
+                "_id": {"$dateToString": {"format": "%Y-%m-%d", "date": "$createdAt"}},
+                "grossSales": {"$sum": {"$ifNull": ["$total", 0]}},
+                "orders": {"$sum": 1},
+            }
+        },
+        {"$sort": {"_id": 1}},
+    ]
+    docs = await coll.aggregate(pipeline).to_list(None)
+    reports = [
+        SalesReport(
+            date=datetime.fromisoformat(doc["_id"]),
+            grossSales=round(doc.get("grossSales", 0.0), 2),
+            orders=doc.get("orders", 0),
+        )
+        for doc in docs
+    ]
+    return reports
+
+
+async def paginate_sales_reports(
+    restaurant_id: str,
+    from_date: datetime,
+    to_date: datetime,
+    limit: int = 10,
+    cursor: Optional[str] = None,
+) -> SalesReportPagination:
+    """Paginate ``SalesReport`` entries for a date range."""
+    reports = await _aggregate_sales(restaurant_id, from_date, to_date)
+    skip = int(cursor) if cursor else 0
+    items = reports[skip : skip + limit]
+    has_more = skip + limit < len(reports)
+    next_cursor = str(skip + limit) if has_more else None
+    return SalesReportPagination(
+        items=items,
+        nextCursor=next_cursor,
+        totalCount=len(reports),
+        hasMore=has_more,
+    )

--- a/docs/tests/reports_test_cases.md
+++ b/docs/tests/reports_test_cases.md
@@ -1,0 +1,13 @@
+# Sales Reports Endpoint Test Cases
+
+This document lists suggested test scenarios for the `/api/v1/reports/sales/paginate` endpoint.
+
+### Basic Behaviour
+- **TC1.1** Provide a valid `restaurantId`, `fromDate` and `toDate` and expect a paginated list of `SalesReport` items ordered by day.
+- **TC1.2** Verify that `limit` restricts the number of returned items and `nextCursor` is provided when more data is available.
+- **TC1.3** Using the returned `nextCursor` should fetch the next page of results.
+
+### Edge Cases
+- **TC2.1** If no invoices exist for the period, the endpoint should return an empty list with `totalCount` set to `0`.
+- **TC2.2** Supplying an invalid cursor should default to the first page.
+- **TC2.3** Invalid restaurant IDs or malformed dates should return HTTP 400 errors.


### PR DESCRIPTION
## Summary
- support paginating daily sales reports
- wire new reports router
- document `/reports/sales/paginate` test cases

## Testing
- `python3.12 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686a5c9d42a083339f054d8af65d533f