### PR TITLE
Implement restaurant daily sales retrieval

### DIFF
--- a/app/api/v1/endpoints/sales.py
+++ b/app/api/v1/endpoints/sales.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi import APIRouter, HTTPException, Body
 
 from app.services import sale as sale_service
@@ -17,3 +19,14 @@ async def register_sale(restaurant_id: str, recipe_id: str = Body(..., alias="re
     if not sale:
         raise HTTPException(status_code=404, detail="Recipe not found")
     return sale.to_response()
+
+
+@router.get("/restaurant/{restaurant_id}/day/{day}")
+async def sales_for_day(restaurant_id: str, day: datetime):
+    """Return sales for a restaurant on a given day."""
+    try:
+        sales = await sale_service.list_sales_for_day(restaurant_id, day)
+        return [s.to_response() for s in sales]
+    except Exception as error:
+        raise HTTPException(status_code=400, detail=str(error))
+

--- a/app/services/sale.py
+++ b/app/services/sale.py
@@ -1,3 +1,4 @@
+from datetime import datetime, timedelta
 from typing import List, Optional
 
 from app.models.sale import SaleModel
@@ -38,3 +39,18 @@ async def create_sale(recipe_id: str, quantity: int) -> Optional[sale_schema.Sal
 
 async def list_sales() -> List[sale_schema.SaleDocument]:
     return await sale_model.get_all()
+
+
+async def list_sales_for_day(
+    restaurant_id: str, day: datetime
+) -> List[sale_schema.SaleDocument]:
+    """Return all sales for a restaurant on a specific day."""
+
+    start = day.replace(hour=0, minute=0, second=0, microsecond=0)
+    end = start + timedelta(days=1)
+    filters = {
+        "restaurantId": restaurant_id,
+        "date": {"$gte": start, "$lt": end},
+    }
+    return await sale_model.get_by_fields(filters)
+

--- a/docs/api/stock-api.md
+++ b/docs/api/stock-api.md
@@ -58,6 +58,7 @@ endpoints and the data shapes used.
 
 ### List sales
 - **GET /api/v1/sales** – Returns array of `Sale`.
+- **GET /api/v1/sales/restaurant/{restaurant_id}/day/{date}** – Returns all sales for a restaurant on a specific day. The `date` should be in `YYYY-MM-DD` format.
 
 ### Register sale
 - **POST /api/v1/sales/restaurant/{restaurant_id}** – Body: `{ recipeId: string, quantity: number }`.


### PR DESCRIPTION
## Summary
- add new `list_sales_for_day` service
- expose `/sales/restaurant/{restaurant_id}/day/{day}` endpoint
- document daily sales endpoint

## Testing
- `pytest -q`
- `python -m py_compile app/services/sale.py app/api/v1/endpoints/sales.py`


------
https://chatgpt.com/codex/tasks/task_e_686bca1d5ea48333beebf9f86679fab6