### PR TITLE
Fix table numbering

### DIFF
--- a/app/api/v1/endpoints/tables.py
+++ b/app/api/v1/endpoints/tables.py
@@ -31,6 +31,8 @@ async def create_table(data: table_schema.TableCreate):
     try:
         table = await table_service.create_table(data)
         return table.to_response()
+    except ValueError as error:
+        raise HTTPException(status_code=400, detail=str(error))
     except Exception as error:
         print(error)
         raise HTTPException(status_code=500, detail=str(error))


### PR DESCRIPTION
## Summary
- keep table numbers in sequence when creating a new one
- disallow duplicate table numbers
- expose bad requests with a 400 HTTP status

## Testing
- `python -m py_compile app/services/table.py app/api/v1/endpoints/tables.py`

------
https://chatgpt.com/codex/tasks/task_e_686d200c9d008333a6e90e6343a22f78