### PR TITLE
Add cancelled sessions analytics endpoint

### DIFF
--- a/app/api/v1/endpoints/analytics.py
+++ b/app/api/v1/endpoints/analytics.py
@@ -8,6 +8,7 @@ from app.services.analytics import (
     count_orders,
     get_top_items,
     count_cancelled_orders,
+    count_cancelled_sessions,
     average_session_duration,
     active_sessions_count, last_seven_days_order_count
 )
@@ -120,6 +121,26 @@ async def cancelled_orders_summary(
 
 
     return await count_cancelled_orders(restaurant_id, from_date, to_date)
+
+
+@router.get("/cancelled-sessions")
+async def cancelled_sessions_summary(
+    restaurant_id: str = Query(..., alias="restaurantId"),
+    from_date: Optional[datetime] = Query(None, alias="fromDate"),
+    to_date: Optional[datetime] = Query(None, alias="toDate"),
+):
+    today = now_in_luanda().replace(hour=0, minute=0, second=0, microsecond=0)
+
+    if not from_date:
+        from_date = today
+    if not to_date:
+        to_date = today + timedelta(days=1)
+    else:
+        to_date = to_date.replace(hour=23, minute=59, second=59, microsecond=0)
+
+    from_date = from_date.replace(hour=0, minute=0, second=0, microsecond=0)
+
+    return await count_cancelled_sessions(restaurant_id, from_date, to_date)
 
 @router.get("/session-duration")
 async def session_duration_summary(

--- a/app/services/analytics.py
+++ b/app/services/analytics.py
@@ -201,6 +201,26 @@ async def count_cancelled_orders(
     return CancelledCount(cancelled_count=count)
 
 
+async def count_cancelled_sessions(
+    restaurant_id: str,
+    from_date: datetime,
+    to_date: datetime
+) -> CancelledCount:
+    """Count the number of cancelled sessions in the period."""
+
+    documents = await session_model.get_by_fields(
+        {
+            "restaurantId": restaurant_id,
+            "status": "cancelled",
+            "startTime": {"$gte": from_date},
+            "endTime": {"$lte": to_date},
+        }
+    )
+    count = len(documents)
+
+    return CancelledCount(cancelled_count=count)
+
+
 async def average_session_duration(
     restaurant_id: str,
     from_date: datetime,

--- a/docs/tests/analytics_test_cases.md
+++ b/docs/tests/analytics_test_cases.md
@@ -46,21 +46,25 @@ This document outlines the basic requirements and a comprehensive list of test c
 - **TC5.1** Valid request should return the count of orders with status `cancelled` in the range.
 - **TC5.2** Requests with no cancelled orders should return `0`.
 
-### 6. Session Duration Endpoint `/api/v1/analytics/session-duration`
-- **TC6.1** Ensure the average session duration is calculated using closed table sessions from today.
-- **TC6.2** If there are no closed sessions, the endpoint should return `0` minutes.
+### 6. Cancelled Sessions Endpoint `/api/v1/analytics/cancelled-sessions`
+- **TC6.1** Valid request returns the number of sessions marked `cancelled` within the date range.
+- **TC6.2** If there are no cancelled sessions, the endpoint returns `0`.
 
-### 7. Active Sessions Endpoint `/api/v1/analytics/active-sessions`
-- **TC7.1** When active sessions exist, verify the count matches table sessions with status `active` and at least one order.
-- **TC7.2** No active sessions should return count `0`.
+### 7. Session Duration Endpoint `/api/v1/analytics/session-duration`
+- **TC7.1** Ensure the average session duration is calculated using closed table sessions from today.
+- **TC7.2** If there are no closed sessions, the endpoint should return `0` minutes.
 
-### 8. Recent Orders Endpoint `/api/v1/analytics/recent-orders`
-- **TC8.1** Should return a list with seven entries representing each of the last seven days.
-- **TC8.2** Each entry should include the ISO date string, weekday name and order count for that day.
+### 8. Active Sessions Endpoint `/api/v1/analytics/active-sessions`
+- **TC8.1** When active sessions exist, verify the count matches table sessions with status `active` and at least one order.
+- **TC8.2** No active sessions should return count `0`.
 
-### 9. General Edge Cases
-- **TC9.1** Verify all endpoints require authentication and deny access otherwise.
-- **TC9.2** Ensure that invalid restaurant IDs or dates return meaningful errors without exposing internals.
-- **TC9.3** Stress test with a large volume of orders and invoices to validate performance and correct aggregation.
+### 9. Recent Orders Endpoint `/api/v1/analytics/recent-orders`
+- **TC9.1** Should return a list with seven entries representing each of the last seven days.
+- **TC9.2** Each entry should include the ISO date string, weekday name and order count for that day.
+
+### 10. General Edge Cases
+- **TC10.1** Verify all endpoints require authentication and deny access otherwise.
+- **TC10.2** Ensure that invalid restaurant IDs or dates return meaningful errors without exposing internals.
+- **TC10.3** Stress test with a large volume of orders and invoices to validate performance and correct aggregation.
 
 These test cases cover the typical and edge scenarios for the analytics workflows and can be implemented using a testing framework such as `pytest` along with HTTP client libraries to simulate requests.


### PR DESCRIPTION
## Summary
- add `count_cancelled_sessions` service to fetch number of cancelled table sessions
- expose `/cancelled-sessions` endpoint in analytics API
- document new endpoint in analytics test cases

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d5863fc348333addfdb586ceafe74