### PR TITLE
Add diagnostics endpoint for orphaned images

### DIFF
--- a/app/api/v1/endpoints/diagnostics.py
+++ b/app/api/v1/endpoints/diagnostics.py
@@ -27,3 +27,10 @@ async def get_orphan_sessions():
 async def run_all_diagnostics():
     """Execute all diagnostic checks and return their results."""
     return await diag_service.run_all()
+
+
+@router.delete("/images/orphans")
+async def delete_orphan_images():
+    """Remove images in cloud storage not linked to any item or restaurant."""
+    deleted = await diag_service.cleanup_unlinked_images()
+    return {"deleted": deleted}


### PR DESCRIPTION
## Summary
- extend diagnostics service to clean up unlinked images
- expose new `DELETE /diagnostics/images/orphans` endpoint

## Testing
- `python -m py_compile app/services/diagnostics.py app/api/v1/endpoints/diagnostics.py`


------
https://chatgpt.com/codex/tasks/task_e_6873e397d2e4833398fd0c1753658fd9