### PR TITLE
Add plan change and payment proof endpoints

### DIFF
--- a/app/api/v1/endpoints/payments.py
+++ b/app/api/v1/endpoints/payments.py
@@ -1,0 +1,57 @@
+from datetime import datetime
+from typing import Optional
+
+from fastapi import APIRouter, Depends, Query, UploadFile, File, Form, HTTPException
+
+from app.services import payment_history as payment_service
+from app.services import subscription as subscription_service
+from app.schema import payment_history as payment_schema
+from app.utils.auth import get_current_user
+
+router = APIRouter()
+
+
+@router.get('/history')
+async def list_payment_history(
+    status: Optional[payment_schema.PaymentStatus] = Query(None),
+    from_date: Optional[datetime] = Query(None, alias='fromDate'),
+    to_date: Optional[datetime] = Query(None, alias='toDate'),
+    uid: str = Depends(get_current_user),
+):
+    sub = await subscription_service.get_user_current_subscription(uid)
+    if not sub:
+        return []
+    payments = await payment_service.list_payments(
+        str(sub.id),
+        from_date=from_date,
+        to_date=to_date,
+        status=status,
+    )
+    return [p.to_response() for p in payments]
+
+
+@router.post('/proofs')
+async def upload_payment_proof(
+    period: str = Form(...),
+    amount: str = Form(...),
+    proof_file: UploadFile = File(..., alias='proofFile'),
+    uid: str = Depends(get_current_user),
+):
+    sub = await subscription_service.get_user_current_subscription(uid)
+    if not sub:
+        raise HTTPException(status_code=404, detail='Subscription not found')
+
+    upload = await payment_service.save_payment_proof(proof_file, str(sub.id))
+    if not upload.success:
+        raise HTTPException(status_code=500, detail='Failed to upload file')
+
+    data = payment_schema.PaymentHistoryCreate(
+        subscriptionId=str(sub.id),
+        period=period,
+        amount=amount,
+        status=payment_schema.PaymentStatus.EM_ANALISE,
+        paymentDate=datetime.utcnow(),
+        receiptUrl=upload.public_url,
+    )
+    record = await payment_service.add_payment_record(data)
+    return record.to_response()

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -23,6 +23,7 @@ from app.api.v1.endpoints.memberships import router as memberships_router
 from app.api.v1.endpoints.orders import router as orders_router
 from app.api.v1.endpoints.invoices import router as invoices_router
 from app.api.v1.endpoints.subscriptions import router as subscriptions_router
+from app.api.v1.endpoints.payments import router as payments_router
 from app.api.v1.endpoints.notifications import router as notifications_router
 from app.api.v1.endpoints.diagnostics import router as diagnostics_router
 from app.api.v1.endpoints.reports import router as reports_router
@@ -58,6 +59,7 @@ router.include_router(invoices_router, prefix="/invoices", tags=["Invoices"])
 router.include_router(
     subscriptions_router, prefix="/subscriptions", tags=["Subscriptions"]
 )
+router.include_router(payments_router, prefix="/payments", tags=["Payments"])
 router.include_router(reports_router, prefix="/reports", tags=["Reports"])
 router.include_router(
     notifications_router, prefix="/notifications", tags=["Notifications"]

--- a/app/core/dependencies.py
+++ b/app/core/dependencies.py
@@ -22,6 +22,7 @@ from app.schema import (
     sale,
     recipe,
     movement,
+    payment_history,
     subscription_plan,
     user_subscription,
     notification
@@ -95,6 +96,7 @@ def get_mongo():
             sale.SaleDocument,
             recipe.RecipeDocument,
             movement.MovementDocument,
+            payment_history.PaymentHistoryDocument,
             subscription_plan.SubscriptionPlanDocument,
             user_subscription.UserSubscriptionDocument,
             notification.NotificationDocument

--- a/app/models/payment_history.py
+++ b/app/models/payment_history.py
@@ -1,0 +1,7 @@
+from app.db.crud import MongoCrud
+from app.schema import payment_history as payment_history_schema
+
+
+class PaymentHistoryModel(MongoCrud[payment_history_schema.PaymentHistoryDocument]):
+    def __init__(self) -> None:
+        super().__init__(payment_history_schema.PaymentHistoryDocument)

--- a/app/schema/payment_history.py
+++ b/app/schema/payment_history.py
@@ -1,0 +1,53 @@
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from beanie import Document
+from bson import ObjectId
+from pydantic import BaseModel, Field
+from pymongo import IndexModel, ASCENDING
+
+from app.schema.collection_id.document_id import DocumentId
+from app.utils.make_optional_model import make_optional_model
+
+
+class PaymentStatus(str, Enum):
+    PAGO = "pago"
+    EM_FALTA = "em_falta"
+    EM_ANALISE = "em_analise"
+
+
+class PaymentHistoryCreate(BaseModel):
+    subscription_id: str = Field(..., alias="subscriptionId")
+    period: str
+    amount: str
+    status: PaymentStatus
+    payment_date: datetime = Field(..., alias="paymentDate")
+    receipt_url: Optional[str] = Field(default=None, alias="receiptUrl")
+
+
+class PaymentHistoryBase(PaymentHistoryCreate):
+    pass
+
+
+PaymentHistoryUpdate = make_optional_model(PaymentHistoryBase)
+
+
+class PaymentHistory(PaymentHistoryBase, DocumentId):
+    model_config = {
+        "populate_by_name": True,
+        "arbitrary_types_allowed": True,
+    }
+
+
+class PaymentHistoryDocument(Document, PaymentHistory):
+    def to_response(self):
+        return PaymentHistory(**self.model_dump(by_alias=True))
+
+    class Settings:
+        name = "payment_history"
+        bson_encoders = {ObjectId: str}
+        indexes = [
+            IndexModel([("subscriptionId", ASCENDING)], name="idx_subscription_id"),
+            IndexModel([("status", ASCENDING)], name="idx_status"),
+        ]

--- a/app/schema/plan.py
+++ b/app/schema/plan.py
@@ -1,11 +1,19 @@
-from typing import List
+from typing import List, Optional
+
+from enum import Enum
 
 from beanie import Document
 from bson import ObjectId
-from pydantic import BaseModel
+from pydantic import BaseModel, Field
 
 from app.schema.collection_id.document_id import DocumentId
 from app.utils.make_optional_model import make_optional_model
+from app.schema.subscription_plan import RecurringInterval
+
+
+class Currency(str, Enum):
+    AOA = "AOA"
+    USD = "USD"
 
 
 class PlanLimits(BaseModel):
@@ -19,8 +27,11 @@ class PlanLimits(BaseModel):
 class PlanCreate(BaseModel):
     name: str
     price: float
-    features: List[str]
-    popular: bool
+    currency: Optional["Currency"] = None
+    interval: Optional[RecurringInterval] = None
+    description: Optional[str] = None
+    popular: Optional[bool] = False
+    features: List[str] = Field(default_factory=list)
     limits: PlanLimits
 
 

--- a/app/schema/user_subscription.py
+++ b/app/schema/user_subscription.py
@@ -13,29 +13,19 @@ from app.utils.time import now_in_luanda
 
 
 class SubscriptionStatus(str, Enum):
-    ACTIVE = "active"
-    CANCELLED = "cancelled"
-    PAST_DUE = "past_due"
-    ENDED = "ended"
-
-
-class PaymentMethod(str, Enum):
-    CREDIT_CARD = "credit_card"
-    PAYPAL = "paypal"
-    OTHER = "other"
+    ATIVA = "ativa"
+    PENDENTE = "pendente"
+    SUSPENSA = "suspensa"
+    CANCELADA = "cancelada"
 
 
 class UserSubscriptionCreate(BaseModel):
     user_id: str = Field(..., alias="userId")
-    plan_id: str = Field(..., alias="planId")
-    status: SubscriptionStatus = SubscriptionStatus.ACTIVE
+    plan_id: Optional[str] = Field(default=None, alias="planId")
     start_date: datetime = Field(default_factory=now_in_luanda, alias="startDate")
     end_date: Optional[datetime] = Field(default=None, alias="endDate")
-    payment_method: Optional[PaymentMethod] = Field(default=None, alias="paymentMethod")
-    last_payment: Optional[datetime] = Field(default=None, alias="lastPayment")
-    next_payment_due: Optional[datetime] = Field(default=None, alias="nextPaymentDue")
-    payment_reference: Optional[str] = Field(default=None, alias="paymentReference")
-    is_auto_renew: bool = Field(default=True, alias="isAutoRenew")
+    status: SubscriptionStatus = SubscriptionStatus.ATIVA
+    auto_renew: Optional[bool] = Field(default=True, alias="autoRenew")
 
 
 class UserSubscriptionBase(UserSubscriptionCreate):

--- a/app/services/payment_history.py
+++ b/app/services/payment_history.py
@@ -1,0 +1,49 @@
+from datetime import datetime
+from typing import Optional, List
+
+from fastapi import UploadFile
+
+from app.models.payment_history import PaymentHistoryModel
+from app.schema import payment_history as payment_schema
+from app.services.google_bucket import get_google_bucket_manager
+
+payment_history_model = PaymentHistoryModel()
+
+
+async def list_payments(
+    subscription_id: str,
+    from_date: Optional[datetime] = None,
+    to_date: Optional[datetime] = None,
+    status: Optional[payment_schema.PaymentStatus] = None,
+) -> List[payment_schema.PaymentHistoryDocument]:
+    filters: dict = {"subscriptionId": subscription_id}
+
+    if from_date or to_date:
+        date_filter: dict = {}
+        if from_date:
+            date_filter["$gte"] = from_date
+        if to_date:
+            date_filter["$lte"] = to_date
+        filters["paymentDate"] = date_filter
+
+    if status:
+        filters["status"] = status
+
+    return await payment_history_model.get_by_fields(filters)
+
+
+async def add_payment_record(
+    data: payment_schema.PaymentHistoryCreate,
+) -> payment_schema.PaymentHistoryDocument:
+    return await payment_history_model.create(data.model_dump(by_alias=True))
+
+
+async def save_payment_proof(
+    file: UploadFile, subscription_id: str
+):
+    manager = get_google_bucket_manager()
+    folder = f"subscriptions/{subscription_id}/payments"
+    return manager.upload_image(
+        await file.read(), filename=file.filename, folder=folder, public=True
+    )
+

--- a/app/services/subscription.py
+++ b/app/services/subscription.py
@@ -1,13 +1,24 @@
-from typing import List, Optional
+from typing import List, Optional, Set
 
 from app.models.subscription_plan import SubscriptionPlanModel
 from app.models.user_subscription import UserSubscriptionModel
+from app.models.user import UserModel
+from app.models.role import RoleModel
+from app.models.table import TableModel
+from app.models.booking import BookingModel
 from app.schema import subscription_plan as plan_schema
 from app.schema import user_subscription as subscription_schema
+from app.schema import table as table_schema
+from app.schema import bookings as booking_schema
+from beanie.operators import In
 from app.utils.time import now_in_luanda
 
 plan_model = SubscriptionPlanModel()
 subscription_model = UserSubscriptionModel()
+user_model = UserModel()
+role_model = RoleModel()
+table_model = TableModel()
+booking_model = BookingModel()
 
 
 # Subscription Plan CRUD
@@ -44,18 +55,67 @@ async def subscribe_user(user_id: str, plan_id: str) -> subscription_schema.User
 
 async def unsubscribe(subscription_id: str) -> Optional[subscription_schema.UserSubscriptionDocument]:
     data = {
-        "status": subscription_schema.SubscriptionStatus.CANCELLED,
+        "status": subscription_schema.SubscriptionStatus.CANCELADA,
         "endDate": now_in_luanda(),
     }
+    return await subscription_model.update(subscription_id, data)
+
+
+async def change_plan(
+    subscription_id: str, plan_id: str, reason: Optional[str] = None
+) -> Optional[subscription_schema.UserSubscriptionDocument]:
+    data = {"planId": plan_id}
     return await subscription_model.update(subscription_id, data)
 
 
 async def get_user_current_subscription(user_id: str) -> Optional[subscription_schema.UserSubscriptionDocument]:
     subs = await subscription_model.get_by_fields({
         "userId": user_id,
-        "status": subscription_schema.SubscriptionStatus.ACTIVE,
+        "status": subscription_schema.SubscriptionStatus.ATIVA,
     })
     if not subs:
         return None
     subs.sort(key=lambda s: s.start_date, reverse=True)
     return subs[0]
+
+
+async def get_usage_metrics(user_id: str) -> dict:
+    """Return usage metrics for the user's subscription."""
+    user = await user_model.get(user_id)
+    if not user:
+        return {"restaurants": 0, "tables": 0, "reservations": 0, "staff": 0}
+
+    active_memberships = [m for m in (user.memberships or []) if m.is_active]
+    role_ids = [m.role_id for m in active_memberships]
+    roles = await role_model.get_many(role_ids) if role_ids else []
+    restaurant_ids: Set[str] = {r.restaurant_id for r in roles}
+
+    if not restaurant_ids:
+        return {"restaurants": 0, "tables": 0, "reservations": 0, "staff": 0}
+
+    table_count = await table_schema.TableDocument.find(
+        In(table_schema.TableDocument.restaurant_id, list(restaurant_ids))
+    ).count()
+
+    reservation_count = await booking_schema.BookingDocument.find(
+        In(booking_schema.BookingDocument.restaurant_id, list(restaurant_ids))
+    ).count()
+
+    roles_in_restaurants = await role_model.get_by_fields({
+        "restaurantId": {"$in": list(restaurant_ids)}
+    })
+    allowed_role_ids = {str(r.id) for r in roles_in_restaurants}
+
+    users = await user_model.get_by_fields({"isActive": True})
+    staff_count = 0
+    for u in users:
+        if u.memberships:
+            if any(m.is_active and m.role_id in allowed_role_ids for m in u.memberships):
+                staff_count += 1
+
+    return {
+        "restaurants": len(restaurant_ids),
+        "tables": table_count,
+        "reservations": reservation_count,
+        "staff": staff_count,
+    }


### PR DESCRIPTION
## Summary
- expose all plans without admin check
- enable changing a user's subscription plan
- allow uploading manual payment proofs

## Testing
- `python -m py_compile app/api/v1/endpoints/subscriptions.py app/api/v1/endpoints/payments.py app/services/subscription.py app/services/payment_history.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ce43d85f883339de1cd11402d4a57