### PR TITLE
Add subscription management endpoints

### DIFF
--- a/app/schema/user_subscription.py
+++ b/app/schema/user_subscription.py
@@ -26,6 +26,7 @@ class UserSubscriptionCreate(BaseModel):
     end_date: Optional[datetime] = Field(default=None, alias="endDate")
     status: SubscriptionStatus = SubscriptionStatus.ATIVA
     auto_renew: Optional[bool] = Field(default=True, alias="autoRenew")
+    pause_reason: Optional[str] = Field(default=None, alias="pauseReason")
 
 
 class UserSubscriptionBase(UserSubscriptionCreate):


### PR DESCRIPTION
## Summary
- extend subscription schema with optional pause reason
- support pausing/resuming subscriptions and generating user backups
- add `POST /subscriptions/pause`, `POST /subscriptions/resume` and `POST /subscriptions/backup` endpoints

## Testing
- `python -m py_compile app/services/subscription.py app/api/v1/endpoints/subscriptions.py app/schema/user_subscription.py`

------
https://chatgpt.com/codex/tasks/task_e_687ceb5cf59c8333a5eff3874bf39814