### PR TITLE
Add dedicated routes for plans, subscriptions and payments

### DIFF
--- a/app/api/v1/endpoints/payments.py
+++ b/app/api/v1/endpoints/payments.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from typing import Optional
 
-from fastapi import APIRouter, Depends, Query, UploadFile, File, Form, HTTPException
+from fastapi import APIRouter, Depends, Query, UploadFile, File, Form, HTTPException, Response
 
 from app.services import payment_history as payment_service
 from app.services import subscription as subscription_service
@@ -14,8 +14,8 @@ router = APIRouter()
 @router.get('/history')
 async def list_payment_history(
     status: Optional[payment_schema.PaymentStatus] = Query(None),
-    from_date: Optional[datetime] = Query(None, alias='fromDate'),
-    to_date: Optional[datetime] = Query(None, alias='toDate'),
+    from_date: Optional[datetime] = Query(None, alias='from'),
+    to_date: Optional[datetime] = Query(None, alias='to'),
     uid: str = Depends(get_current_user),
 ):
     sub = await subscription_service.get_user_current_subscription(uid)
@@ -55,3 +55,24 @@ async def upload_payment_proof(
     )
     record = await payment_service.add_payment_record(data)
     return record.to_response()
+
+
+@router.get('/latest-invoice')
+async def get_latest_invoice(uid: str = Depends(get_current_user)):
+    sub = await subscription_service.get_user_current_subscription(uid)
+    if not sub:
+        raise HTTPException(status_code=404, detail='Subscription not found')
+    payment = await payment_service.get_latest_payment(str(sub.id))
+    if not payment:
+        raise HTTPException(status_code=404, detail='No payments found')
+    blob = payment_service.generate_invoice_blob(payment)
+    return Response(content=blob, media_type='application/octet-stream')
+
+
+@router.get('/invoice/{payment_id}')
+async def download_invoice(payment_id: str):
+    payment = await payment_service.get_payment(payment_id)
+    if not payment:
+        raise HTTPException(status_code=404, detail='Payment not found')
+    blob = payment_service.generate_invoice_blob(payment)
+    return Response(content=blob, media_type='application/octet-stream')

--- a/app/api/v1/endpoints/plans.py
+++ b/app/api/v1/endpoints/plans.py
@@ -1,0 +1,69 @@
+from typing import Optional, Dict, Any
+
+from fastapi import APIRouter, HTTPException, Depends, Query
+
+from app.services import subscription as subscription_service
+from app.schema import subscription_plan as plan_schema
+from app.services.subscription import plan_model
+from app.utils.auth import admin_required
+
+router = APIRouter()
+
+
+@router.get("/paginate")
+async def paginate_plans(
+    limit: int = Query(10, gt=0),
+    cursor: Optional[str] = Query(None),
+):
+    try:
+        filters: Dict[str, Any] = {}
+        result = await plan_model.paginate(filters=filters, limit=limit, cursor=cursor)
+        return result
+    except Exception as error:
+        print(error)
+
+
+@router.post("/", dependencies=[Depends(admin_required)])
+async def create_plan(data: plan_schema.SubscriptionPlanCreate):
+    try:
+        plan = await subscription_service.create_plan(data)
+        return plan.to_response()
+    except Exception as e:
+        print(str(e))
+        raise HTTPException(status_code=400, detail=str(e))
+
+
+@router.put("/{plan_id}", dependencies=[Depends(admin_required)])
+async def update_plan(plan_id: str, data: plan_schema.SubscriptionPlanUpdate):
+    updated = await subscription_service.update_plan(plan_id, data)
+    if not updated:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    return updated.to_response()
+
+
+@router.delete("/{plan_id}", dependencies=[Depends(admin_required)])
+async def delete_plan(plan_id: str):
+    deleted = await subscription_service.delete_plan(plan_id)
+    if not deleted:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    return True
+
+
+@router.get("/{plan_id}")
+async def get_plan(plan_id: str):
+    plan = await subscription_service.get_plan(plan_id)
+    if not plan:
+        raise HTTPException(status_code=404, detail="Plan not found")
+    return plan.to_response()
+
+
+@router.get("/")
+async def list_available_plans():
+    plans = await subscription_service.list_plans(active_only=True)
+    return [p.to_response() for p in plans]
+
+
+@router.get("/all")
+async def list_all_plans():
+    plans = await subscription_service.list_plans()
+    return [p.to_response() for p in plans]

--- a/app/api/v1/endpoints/subscriptions.py
+++ b/app/api/v1/endpoints/subscriptions.py
@@ -1,13 +1,12 @@
 from typing import Optional, Dict, Any
 
-from fastapi import APIRouter, HTTPException, Depends, Query
+from fastapi import APIRouter, HTTPException, Depends, Query, Response
 from pydantic import BaseModel, Field
 
 from app.services import subscription as subscription_service
-from app.schema import subscription_plan as plan_schema
 from app.schema import user_subscription as subscription_schema
-from app.services.subscription import subscription_model, plan_model
-from app.utils.auth import admin_required, get_current_user
+from app.services.subscription import subscription_model
+from app.utils.auth import get_current_user
 
 router = APIRouter()
 
@@ -15,68 +14,6 @@ router = APIRouter()
 class ChangePlanRequest(BaseModel):
     plan_id: str = Field(..., alias="planId")
     reason: Optional[str] = None
-
-
-# Subscription Plan CRUD
-
-@router.get("/plans/paginate")
-async def paginate_plans(
-    limit: int = Query(10, gt=0),
-    cursor: Optional[str] = Query(None),
-):
-    try:
-        filters: Dict[str, Any] = {}
-
-        result = await plan_model.paginate(filters=filters, limit=limit, cursor=cursor)
-
-        return result
-    except Exception as error:
-        print(error)
-
-@router.post('/plans', dependencies=[Depends(admin_required)])
-async def create_plan(data: plan_schema.SubscriptionPlanCreate):
-    try:
-        plan = await subscription_service.create_plan(data)
-        return plan.to_response()
-    except Exception as e:
-        print(str(e))
-        raise HTTPException(status_code=400, detail=str(e))
-
-
-@router.put('/plans/{plan_id}', dependencies=[Depends(admin_required)])
-async def update_plan(plan_id: str, data: plan_schema.SubscriptionPlanUpdate):
-    updated = await subscription_service.update_plan(plan_id, data)
-    if not updated:
-        raise HTTPException(status_code=404, detail='Plan not found')
-    return updated.to_response()
-
-
-@router.delete('/plans/{plan_id}', dependencies=[Depends(admin_required)])
-async def delete_plan(plan_id: str):
-    deleted = await subscription_service.delete_plan(plan_id)
-    if not deleted:
-        raise HTTPException(status_code=404, detail='Plan not found')
-    return True
-
-
-@router.get('/plans/{plan_id}')
-async def get_plan(plan_id: str):
-    plan = await subscription_service.get_plan(plan_id)
-    if not plan:
-        raise HTTPException(status_code=404, detail='Plan not found')
-    return plan.to_response()
-
-
-@router.get('/plans')
-async def list_available_plans():
-    plans = await subscription_service.list_plans(active_only=True)
-    return [p.to_response() for p in plans]
-
-
-@router.get('/plans/all')
-async def list_all_plans():
-    plans = await subscription_service.list_plans()
-    return [p.to_response() for p in plans]
 
 
 # User Subscription Endpoints
@@ -152,3 +89,25 @@ async def get_my_subscription(uid: str = Depends(get_current_user)):
 @router.get('/usage')
 async def get_usage(uid: str = Depends(get_current_user)):
     return await subscription_service.get_usage_metrics(uid)
+
+
+@router.post('/{subscription_id}/pause')
+async def pause_subscription(subscription_id: str):
+    updated = await subscription_service.pause_subscription(subscription_id)
+    if not updated:
+        raise HTTPException(status_code=404, detail='Subscription not found')
+    return updated.to_response()
+
+
+@router.post('/{subscription_id}/resume')
+async def resume_subscription(subscription_id: str):
+    updated = await subscription_service.resume_subscription(subscription_id)
+    if not updated:
+        raise HTTPException(status_code=404, detail='Subscription not found')
+    return updated.to_response()
+
+
+@router.get('/backup')
+async def backup_account_data_endpoint(uid: str = Depends(get_current_user)):
+    blob = await subscription_service.backup_account_data(uid)
+    return Response(content=blob, media_type='application/octet-stream')

--- a/app/api/v1/router.py
+++ b/app/api/v1/router.py
@@ -23,6 +23,7 @@ from app.api.v1.endpoints.memberships import router as memberships_router
 from app.api.v1.endpoints.orders import router as orders_router
 from app.api.v1.endpoints.invoices import router as invoices_router
 from app.api.v1.endpoints.subscriptions import router as subscriptions_router
+from app.api.v1.endpoints.plans import router as plans_router
 from app.api.v1.endpoints.payments import router as payments_router
 from app.api.v1.endpoints.notifications import router as notifications_router
 from app.api.v1.endpoints.diagnostics import router as diagnostics_router
@@ -59,6 +60,7 @@ router.include_router(invoices_router, prefix="/invoices", tags=["Invoices"])
 router.include_router(
     subscriptions_router, prefix="/subscriptions", tags=["Subscriptions"]
 )
+router.include_router(plans_router, prefix="/plans", tags=["Subscription Plans"])
 router.include_router(payments_router, prefix="/payments", tags=["Payments"])
 router.include_router(reports_router, prefix="/reports", tags=["Reports"])
 router.include_router(

--- a/app/services/payment_history.py
+++ b/app/services/payment_history.py
@@ -47,3 +47,32 @@ async def save_payment_proof(
         await file.read(), filename=file.filename, folder=folder, public=True
     )
 
+
+async def get_payment(payment_id: str) -> Optional[payment_schema.PaymentHistoryDocument]:
+    """Retrieve a payment record by its id."""
+    return await payment_history_model.get(payment_id)
+
+
+async def get_latest_payment(subscription_id: str) -> Optional[payment_schema.PaymentHistoryDocument]:
+    """Return the most recent payment for a subscription."""
+    docs = (
+        await payment_schema.PaymentHistoryDocument.find(
+            payment_schema.PaymentHistoryDocument.subscription_id == subscription_id
+        )
+        .sort("-paymentDate")
+        .limit(1)
+        .to_list()
+    )
+    return docs[0] if docs else None
+
+
+def generate_invoice_blob(payment: payment_schema.PaymentHistoryDocument) -> bytes:
+    """Generate a simple invoice representation as bytes."""
+    content = (
+        f"Invoice for payment {payment.id}\n"
+        f"Period: {payment.period}\n"
+        f"Amount: {payment.amount}\n"
+        f"Status: {payment.status}"
+    )
+    return content.encode("utf-8")
+


### PR DESCRIPTION
## Summary
- split plans endpoints into their own router
- update subscription endpoints and add pause/resume and backup
- extend payment endpoints with invoice helpers and param renames
- expose new routers in API router
- add helper functions to subscription and payment services

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883b18beaf08333ab58c5f83d650f5a