### PR TITLE
Use consistent Luanda time helpers

### DIFF
--- a/app/api/v1/endpoints/auth.py
+++ b/app/api/v1/endpoints/auth.py
@@ -17,7 +17,7 @@ from app.models.user import UserModel
 from app.schema.user import User, UserCreate
 from firebase_admin import auth
 
-from app.utils.time import now_in_luanda, to_luanda_timezone
+from app.utils.time import now_in_luanda
 
 router = APIRouter()
 user_model = UserModel()
@@ -47,7 +47,7 @@ async def login(
         user = await user_model.get_user_by_firebase_uid(firebase_uid)
 
         await user_model.update(str(user.id), {
-            "lastLogged": to_luanda_timezone(now_in_luanda())
+            "lastLogged": now_in_luanda()
         })
 
         # if not user:

--- a/app/db/crud.py
+++ b/app/db/crud.py
@@ -10,7 +10,7 @@ from pydantic import Field, BaseModel
 from pymongo import DESCENDING
 
 from app.schema.collection_id.object_id import PyObjectId
-from app.utils.time import now_in_luanda, to_luanda_timezone
+from app.utils.time import now_in_luanda
 
 T = TypeVar("T", bound=Document)
 
@@ -57,8 +57,8 @@ class MongoCrud(Generic[T]):
         return await self._get_collection().count_documents({})
 
     async def create(self, data: Dict[str, Any]) -> T:
-        data["created_at"] = to_luanda_timezone(now_in_luanda())
-        data["updated_at"] = to_luanda_timezone(now_in_luanda())
+        data["created_at"] = now_in_luanda()
+        data["updated_at"] = now_in_luanda()
 
         document = self.model(**data)
         return await document.insert()
@@ -112,7 +112,7 @@ class MongoCrud(Generic[T]):
 
         # Optional: ensure updated_at is applied
         if "updated_at" in self.model.model_fields:
-            data["updatedAt"] = to_luanda_timezone(now_in_luanda())
+            data["updatedAt"] = now_in_luanda()
 
         result = await collection.update_one(
             {"_id": ObjectId(_id)},

--- a/app/models/stock_item.py
+++ b/app/models/stock_item.py
@@ -5,7 +5,7 @@ from app.schema import stock_item as stock_item_schema
 from app.schema.stock_item import StockStatus
 from app.schema import movement as movement_schema
 from app.models.movement import MovementModel
-from app.utils.time import now_in_luanda, to_luanda_timezone
+from app.utils.time import now_in_luanda
 
 movement_model = MovementModel()
 
@@ -37,7 +37,7 @@ class StockItemModel(MongoCrud[stock_item_schema.StockItemDocument]):
                 "quantity": quantity,
                 "restaurantId": new_stock_item.restaurant_id,
                 "unit": new_stock_item.unit,
-                "date": to_luanda_timezone(now_in_luanda()),
+                "date": now_in_luanda(),
                 "reason": reason or "Item created",
                 "user": "Ajuste automático",
                 "cost": new_stock_item.cost,
@@ -63,7 +63,7 @@ class StockItemModel(MongoCrud[stock_item_schema.StockItemDocument]):
                 "quantity": abs(new_quantity - item.current_quantity),
                 "restaurantId": item.restaurant_id,
                 "unit": item.unit,
-                "date": to_luanda_timezone(now_in_luanda()),
+                "date": now_in_luanda(),
                 "reason": reason,
                 "user": "Ajuste automático",
                 "cost": item.cost,
@@ -86,7 +86,7 @@ class StockItemModel(MongoCrud[stock_item_schema.StockItemDocument]):
                 "quantity": item.current_quantity,
                 "restaurantId": item.restaurant_id,
                 "unit": item.unit,
-                "date": to_luanda_timezone(now_in_luanda()),
+                "date": now_in_luanda(),
                 "reason": reason or "Item deleted",
                 "user": "Ajuste automático",
                 "cost": item.cost,

--- a/app/schema/movement.py
+++ b/app/schema/movement.py
@@ -9,7 +9,7 @@ from pymongo import IndexModel, ASCENDING
 
 from app.schema.collection_id.document_id import DocumentId
 from app.utils.make_optional_model import make_optional_model
-from app.utils.time import now_in_luanda
+from app.utils.time import now_in_luanda, to_luanda_timezone
 
 
 class MovementType(str, Enum):
@@ -32,7 +32,7 @@ class MovementCreate(BaseModel):
 
     @field_serializer('date')
     def serialize_start_time(self, value: datetime, _info):
-        return to_luanda_timezone(now_in_luanda())
+        return to_luanda_timezone(value)
 
 
 class MovementBase(MovementCreate):


### PR DESCRIPTION
## Summary
- store MongoDB timestamps using `now_in_luanda`
- serialize movement dates with `to_luanda_timezone`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68928969669083338b2a3e934552ba92