### PR TITLE
Refactor insights endpoints to fetch data by restaurant ID

### DIFF
--- a/app/api/v1/endpoints/insights.py
+++ b/app/api/v1/endpoints/insights.py
@@ -1,7 +1,8 @@
-from typing import List, Optional
+from collections import defaultdict
+from datetime import datetime, timedelta
+from typing import List
 
 from fastapi import APIRouter
-from pydantic import BaseModel
 
 from app.services.ai import (
     OrderData,
@@ -12,41 +13,117 @@ from app.services.ai import (
     InsightItem,
     InsightPriority,
     AnalysisType,
-    RestaurantDocument,
 )
+from app.services import order as order_service
+from app.services import table as table_service
+from app.services import restaurant as restaurant_service
+from app.services.table_session import session_model
+from app.utils.time import now_in_luanda
+
 
 router = APIRouter()
 
 analyzer = RestaurantInsightsAnalyzer()
 
 
-class FullInsightsRequest(BaseModel):
-    restaurant: RestaurantDocument
-    orders: Optional[List[OrderData]] = None
-    occupancy: Optional[List[TableOccupancy]] = None
-    reviews: Optional[List[CustomerReview]] = None
+async def _get_order_data(restaurant_id: str) -> List[OrderData]:
+    orders = await order_service.list_orders_for_restaurant(restaurant_id)
+    data: List[OrderData] = []
+    for o in orders:
+        items = [o.ordered_item_name] if getattr(o, "ordered_item_name", None) else [o.item_id]
+        data.append(
+            OrderData(
+                order_id=str(o.id),
+                revenue=o.total or 0,
+                timestamp=o.order_time,
+                items=items,
+                table_number=o.table_number,
+            )
+        )
+    return data
 
 
-@router.post("/performance")
-async def performance_insights(data: List[OrderData]):
+async def _get_occupancy_data(restaurant_id: str) -> List[TableOccupancy]:
+    tables = await table_service.list_tables_for_restaurant(restaurant_id)
+    total_tables = len(tables)
+    if total_tables == 0:
+        return []
+
+    sessions = await session_model.get_by_fields({"restaurantId": restaurant_id})
+    now = now_in_luanda()
+    occ_map: dict[datetime.date, dict[int, int]] = defaultdict(lambda: defaultdict(int))
+
+    for s in sessions:
+        start = s.start_time.replace(minute=0, second=0, microsecond=0)
+        end = (s.end_time or now).replace(minute=0, second=0, microsecond=0)
+        current = start
+        while current <= end:
+            occ_map[current.date()][current.hour] += 1
+            current += timedelta(hours=1)
+
+    data: List[TableOccupancy] = []
+    for date, hours in occ_map.items():
+        for hour, occupied in hours.items():
+            data.append(
+                TableOccupancy(
+                    date=datetime.combine(date, datetime.min.time()),
+                    hour=hour,
+                    occupied_tables=occupied,
+                    total_tables=total_tables,
+                )
+            )
+    return data
+
+
+async def _get_review_data(restaurant_id: str) -> List[CustomerReview]:
+    sessions = await session_model.get_by_fields({"restaurantId": restaurant_id, "review": {"$ne": None}})
+    reviews: List[CustomerReview] = []
+    for s in sessions:
+        if s.review:
+            reviews.append(
+                CustomerReview(
+                    review_id=str(s.id),
+                    text=s.review.comment or "",
+                    rating=s.review.stars,
+                    timestamp=s.end_time or s.start_time,
+                    verified=True,
+                    source="internal",
+                )
+            )
+    return reviews
+
+
+@router.get("/performance/{restaurant_id}")
+async def performance_insights(restaurant_id: str):
+    data = await _get_order_data(restaurant_id)
     return await analyzer.processors[AnalysisType.PERFORMANCE].process(data)
 
 
-@router.post("/occupancy")
-async def occupancy_insights(data: List[TableOccupancy]):
+@router.get("/occupancy/{restaurant_id}")
+async def occupancy_insights(restaurant_id: str):
+    data = await _get_occupancy_data(restaurant_id)
     return await analyzer.processors[AnalysisType.OCCUPANCY].process(data)
 
 
-@router.post("/sentiment")
-async def sentiment_insights(data: List[CustomerReview]):
+@router.get("/sentiment/{restaurant_id}")
+async def sentiment_insights(restaurant_id: str):
+    data = await _get_review_data(restaurant_id)
     return await analyzer.processors[AnalysisType.SENTIMENT].process(data)
 
 
-@router.post("/full", response_model=InsightsOutput)
-async def generate_full_insights(req: FullInsightsRequest):
-    trends, occ, sentiment = await analyzer._process_data_sources(
-        req.orders, req.occupancy, req.reviews
-    )
+@router.get("/full/{restaurant_id}", response_model=InsightsOutput)
+async def generate_full_insights(restaurant_id: str):
+    restaurant = await restaurant_service.get_restaurant(restaurant_id)
+    orders = await _get_order_data(restaurant_id)
+    occupancy = await _get_occupancy_data(restaurant_id)
+    reviews = await _get_review_data(restaurant_id)
+
+    cache_key = analyzer._generate_cache_key(restaurant, orders, occupancy, reviews)
+    cached = analyzer._check_cache(cache_key)
+    if cached:
+        return cached
+
+    trends, occ, sentiment = await analyzer._process_data_sources(orders, occupancy, reviews)
     quality, confidence = analyzer._assess_data_quality(trends, occ, sentiment)
 
     prompt = (
@@ -69,7 +146,7 @@ async def generate_full_insights(req: FullInsightsRequest):
             for i in items
         ]
 
-    return InsightsOutput(
+    output = InsightsOutput(
         summary=llm_result.get("summary", ""),
         top_recommendations=to_items(
             llm_result.get("recommendations", []), "recommendation"
@@ -81,3 +158,6 @@ async def generate_full_insights(req: FullInsightsRequest):
         data_quality=quality,
         confidence_score=confidence,
     )
+    analyzer._store_cache(cache_key, output)
+    return output
+

--- a/docs/api/insights_api.md
+++ b/docs/api/insights_api.md
@@ -1,0 +1,34 @@
+# Insights API
+
+These endpoints generate analytical insights for a restaurant using data
+already stored in the system. Instead of submitting raw data, provide the
+restaurant's identifier and the service will gather orders, table sessions
+and reviews automatically.
+
+## Endpoints
+
+### `GET /api/v1/insights/performance/{restaurant_id}`
+Returns performance trends derived from historical orders of the specified
+restaurant.
+
+### `GET /api/v1/insights/occupancy/{restaurant_id}`
+Analyses table sessions to compute occupancy rates and utilization metrics.
+
+### `GET /api/v1/insights/sentiment/{restaurant_id}`
+Evaluates customer feedback left in table session reviews and returns
+sentiment insights.
+
+### `GET /api/v1/insights/full/{restaurant_id}`
+Combines order trends, occupancy statistics and review sentiment into a
+comprehensive insights report. The response matches the `InsightsOutput`
+schema used by the service.
+
+## Example
+
+```http
+GET /api/v1/insights/full/64b9...
+```
+
+The response includes a high level summary along with recommendations,
+risks, opportunities, a data quality grade and confidence score.
+


### PR DESCRIPTION
## Summary
- Refactor insights routes to pull orders, occupancy and reviews from the database using the restaurant ID
- Add caching and generation logic for full insights
- Document insights API usage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68965098761483339e9587b99ade5036