### PR TITLE
feat: add narrative insights responses

### DIFF
--- a/app/api/v1/endpoints/insights.py
+++ b/app/api/v1/endpoints/insights.py
@@ -99,13 +99,23 @@ async def performance_insights(restaurant_id: str):
     metrics = await analyzer.processors[AnalysisType.PERFORMANCE].process(data)
     if "error" in metrics:
         return metrics
-    insight = (
-        f"Total orders {metrics.get('total_orders', 0)} generated revenue of "
-        f"${metrics.get('total_revenue', 0):.2f}. "
-        f"Peak hours: {', '.join(map(str, metrics.get('peak_hours', [])))}. "
-        f"Best days: {', '.join(metrics.get('best_days', []))}."
-    )
-    return {"insight": insight}
+    total_orders = metrics.get("total_orders", 0)
+    revenue = metrics.get("total_revenue", 0)
+    peak_hours = ", ".join(map(str, metrics.get("peak_hours", []))) or "none identified"
+    best_days = ", ".join(metrics.get("best_days", [])) or "no standout days"
+
+    if total_orders == 0:
+        opinion = "No orders were found for this restaurant, so performance cannot be assessed."
+    else:
+        performance = (
+            "strong" if revenue > 10000 else "steady" if revenue > 5000 else "developing"
+        )
+        opinion = (
+            f"The restaurant handled {total_orders} orders generating ${revenue:.2f}, "
+            f"showing {performance} sales performance. Peak activity occurs around {peak_hours}, "
+            f"with best results on {best_days}. Consider reinforcing popular periods and exploring promotions during quieter times."
+        )
+    return {"insight": opinion}
 
 
 @router.get("/occupancy/{restaurant_id}")
@@ -114,12 +124,22 @@ async def occupancy_insights(restaurant_id: str):
     metrics = await analyzer.processors[AnalysisType.OCCUPANCY].process(data)
     if "error" in metrics:
         return metrics
-    insight = (
-        f"Average occupancy rate {metrics.get('avg_occupancy_rate', 0):.0%}. "
-        f"Peak hours: {', '.join(map(str, metrics.get('peak_hours', [])))}. "
-        f"Underutilized hours: {', '.join(map(str, metrics.get('underutilized_hours', [])))}."
-    )
-    return {"insight": insight}
+    avg_rate = metrics.get("avg_occupancy_rate", 0)
+    peak_hours = ", ".join(map(str, metrics.get("peak_hours", []))) or "none identified"
+    low_hours = ", ".join(map(str, metrics.get("underutilized_hours", []))) or "none"
+
+    if avg_rate == 0:
+        opinion = "No table occupancy data available to evaluate utilization."
+    else:
+        utilization = (
+            "excellent" if avg_rate >= 0.8 else "good" if avg_rate >= 0.6 else "needs improvement"
+        )
+        opinion = (
+            f"Average occupancy sits at {avg_rate:.0%}, indicating {utilization} space usage. "
+            f"Tables are busiest around {peak_hours}, while {low_hours} remain underused. "
+            f"Balancing these periods could improve overall efficiency."
+        )
+    return {"insight": opinion}
 
 
 @router.get("/sentiment/{restaurant_id}")
@@ -129,13 +149,18 @@ async def sentiment_insights(restaurant_id: str):
     if "error" in metrics:
         return metrics
     dist = metrics.get("sentiment_distribution", {})
-    insight = (
-        f"Overall sentiment {metrics.get('overall_sentiment', 'neutral')} with "
-        f"{dist.get('positive', 0)} positive, {dist.get('negative', 0)} negative, "
-        f"{dist.get('neutral', 0)} neutral reviews. "
-        f"Average rating: {metrics.get('avg_rating')}"
-    )
-    return {"insight": insight}
+    total = sum(dist.values())
+    if total == 0:
+        opinion = "No customer reviews were found to assess sentiment."
+    else:
+        overall = metrics.get("overall_sentiment", "neutral")
+        avg_rating = metrics.get("avg_rating")
+        opinion = (
+            f"Customer sentiment is predominantly {overall} with {dist.get('positive', 0)} positive and "
+            f"{dist.get('negative', 0)} negative mentions out of {total} reviews. "
+            f"The average rating is {avg_rating}. Addressing recurring issues in negative feedback could enhance guest satisfaction."
+        )
+    return {"insight": opinion}
 
 
 @router.get("/full/{restaurant_id}", response_model=InsightsOutput)

--- a/docs/api/insights_api.md
+++ b/docs/api/insights_api.md
@@ -8,16 +8,16 @@ and reviews automatically.
 ## Endpoints
 
 ### `GET /api/v1/insights/performance/{restaurant_id}`
-Returns a text summary of performance trends derived from historical orders
-of the specified restaurant.
+Returns a narrative analysis of performance trends derived from historical
+orders of the specified restaurant.
 
 ### `GET /api/v1/insights/occupancy/{restaurant_id}`
-Analyzes table sessions to compute occupancy rates and returns a text
-summary of utilization metrics.
+Analyzes table sessions to compute occupancy rates and returns a helpful
+opinion on table utilization.
 
 ### `GET /api/v1/insights/sentiment/{restaurant_id}`
-Evaluates customer feedback left in table session reviews and returns a
-textual sentiment insight.
+Evaluates customer feedback left in table session reviews and produces an
+overall sentiment assessment with guidance.
 
 ### `GET /api/v1/insights/full/{restaurant_id}`
 Combines order trends, occupancy statistics and review sentiment into a

--- a/docs/tests/insights_test_cases.md
+++ b/docs/tests/insights_test_cases.md
@@ -18,17 +18,17 @@ This document outlines the basic requirements and an extensive list of test case
 ## Test Cases
 
 ### 1. Performance Insights Endpoint `/api/v1/insights/performance`
-- **TC1.1** Valid list of `OrderData` objects returns detailed trend metrics.
+- **TC1.1** Valid list of `OrderData` objects returns a helpful narrative summarising performance.
 - **TC1.2** Fewer than three orders returns `{ "error": "Insufficient order data for analysis" }`.
 - **TC1.3** Invalid order fields (e.g. negative revenue) return HTTP 422.
 
 ### 2. Occupancy Insights Endpoint `/api/v1/insights/occupancy`
-- **TC2.1** Valid list of `TableOccupancy` objects returns utilization statistics.
+- **TC2.1** Valid list of `TableOccupancy` objects returns utilization opinions.
 - **TC2.2** Fewer than five occupancy records returns `{ "error": "Insufficient occupancy data" }`.
 - **TC2.3** Invalid occupancy fields (e.g. hour out of range) return HTTP 422.
 
 ### 3. Sentiment Insights Endpoint `/api/v1/insights/sentiment`
-- **TC3.1** Valid list of `CustomerReview` objects returns sentiment breakdown and theme analysis.
+- **TC3.1** Valid list of `CustomerReview` objects returns overall sentiment analysis with narrative.
 - **TC3.2** Fewer than three reviews returns `{ "error": "Insufficient review data" }`.
 - **TC3.3** Invalid review fields (e.g. rating > 5) return HTTP 422.
 


### PR DESCRIPTION
## Summary
- enhance performance insights endpoint with narrative opinions based on order metrics
- provide occupancy insight opinions describing utilization and inefficiency
- describe customer sentiment with narrative analysis and update docs accordingly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68965c613180833385a474457929bb11