### PR TITLE
Ensure insights use configured OpenAI API key

### DIFF
--- a/app/api/v1/endpoints/insights.py
+++ b/app/api/v1/endpoints/insights.py
@@ -13,16 +13,21 @@ from app.services.ai import (
     InsightItem,
     InsightPriority,
     AnalysisType,
+    LLMConfig,
 )
 from app.services import order as order_service
 from app.services import table as table_service
 from app.services import restaurant as restaurant_service
 from app.services.table_session import session_model
 from app.utils.time import now_in_luanda, to_luanda_timezone
+from app.core.dependencies import get_settings
 
 router = APIRouter()
 
-analyzer = RestaurantInsightsAnalyzer()
+settings = get_settings()
+analyzer = RestaurantInsightsAnalyzer(
+    llm_config=LLMConfig(api_key=settings.OPENAI_API_KEY)
+)
 
 
 async def _get_order_data(restaurant_id: str) -> List[OrderData]:

--- a/app/services/ai.py
+++ b/app/services/ai.py
@@ -20,6 +20,7 @@ from pydantic import BaseModel, Field, validator
 from beanie import Document
 import openai
 
+from app.core.config import Settings
 from app.utils.time import now_in_luanda
 
 # Configure logging
@@ -560,6 +561,9 @@ class OpenAIProvider(LLMProvider):
     async def generate_insights(self, prompt: str, config: LLMConfig) -> Dict[str, Any]:
         """Generate insights using OpenAI API"""
         try:
+            if not config.api_key:
+                settings = Settings()
+                config.api_key = settings.OPENAI_API_KEY
 
             openai.api_key = config.api_key
 


### PR DESCRIPTION
## Summary
- initialize insights analyzer with API key from settings
- fall back to configured OpenAI API key in provider

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689676a12f8c83338eeb3adf5e5e5fea