### PR TITLE
Fix insights asynchronous processing and timezone handling

### DIFF
--- a/app/api/v1/endpoints/insights.py
+++ b/app/api/v1/endpoints/insights.py
@@ -69,8 +69,16 @@ async def _get_occupancy_data(restaurant_id: str, days: int) -> List[TableOccupa
 
     try:
         for s in sessions:
-            start = to_luanda_timezone(s.start_time).replace(minute=0, second=0, microsecond=0)
-            end = (to_luanda_timezone(s.end_time) or now).replace(minute=0, second=0, microsecond=0)
+            if not s.start_time:
+                continue
+
+            start_dt = to_luanda_timezone(s.start_time)
+            if start_dt is None:
+                continue
+
+            start = start_dt.replace(minute=0, second=0, microsecond=0)
+            end_dt = to_luanda_timezone(s.end_time) or now
+            end = end_dt.replace(minute=0, second=0, microsecond=0)
             current = start
             while current <= end:
                 occ_map[current.date()][current.hour] += 1

--- a/app/services/ai.py
+++ b/app/services/ai.py
@@ -708,23 +708,34 @@ class RestaurantInsightsAnalyzer:
 
         tasks = []
 
+        async def _error_result(message: str) -> Dict[str, Any]:
+            """Return an async error result.
+
+            Python 3.11+ removed ``asyncio.coroutine`` which was previously used
+            to fabricate asynchronous results for missing data.  Using an
+            ``async`` helper keeps the interface consistent without relying on
+            deprecated APIs.
+            """
+
+            return {"error": message}
+
         # Process time series data
         if order_data:
             tasks.append(self.processors[AnalysisType.PERFORMANCE].process(order_data))
         else:
-            tasks.append(asyncio.create_task(asyncio.coroutine(lambda: {"error": "No order data"})()))
+            tasks.append(_error_result("No order data"))
 
         # Process occupancy data
         if table_occupancy:
             tasks.append(self.processors[AnalysisType.OCCUPANCY].process(table_occupancy))
         else:
-            tasks.append(asyncio.create_task(asyncio.coroutine(lambda: {"error": "No occupancy data"})()))
+            tasks.append(_error_result("No occupancy data"))
 
         # Process sentiment data
         if customer_reviews:
             tasks.append(self.processors[AnalysisType.SENTIMENT].process(customer_reviews))
         else:
-            tasks.append(asyncio.create_task(asyncio.coroutine(lambda: {"error": "No review data"})()))
+            tasks.append(_error_result("No review data"))
 
         return await asyncio.gather(*tasks)
 

--- a/app/utils/time.py
+++ b/app/utils/time.py
@@ -1,13 +1,26 @@
 from datetime import datetime, timezone
+from typing import Optional
+
 import pytz
 
 
-def now_in_luanda():
+def now_in_luanda() -> datetime:
     """Returns the current datetime in the Luanda, Angola timezone (WAT, UTC+1)."""
     return datetime.now(timezone.utc)
 
 
-def to_luanda_timezone(value: datetime):
+def to_luanda_timezone(value: Optional[datetime]) -> Optional[datetime]:
+    """Convert a datetime to the Africa/Luanda timezone.
+
+    If ``value`` is ``None`` the function safely returns ``None`` instead of
+    raising an :class:`AttributeError` when attempting to access
+    ``value.tzinfo``.  This ensures callers can pass optional datetimes without
+    additional ``None`` checks.
+    """
+
+    if value is None:
+        return None
+
     if value.tzinfo is None:
         value = value.replace(tzinfo=timezone.utc)
     return value.astimezone(pytz.timezone("Africa/Luanda"))


### PR DESCRIPTION
## Summary
- Avoid deprecated `asyncio.coroutine` by using async helper for missing data cases
- Allow `to_luanda_timezone` to accept `None` safely and add guards for missing session start times
- Improve data source processing reliability for full insights generation

## Testing
- `python -m py_compile app/services/ai.py app/utils/time.py app/api/v1/endpoints/insights.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68968dda2aa88333bb4bd68b45342d2e